### PR TITLE
Add Ukrainian and Russian localizations

### DIFF
--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -1,0 +1,131 @@
+# Russian translation for BoxBuddy.
+# Copyright (C) 2024 THE BoxBuddy'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# volkov <volkovissocool@gmail.com>, 2024.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: DistroBuddy\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-06 13:06+0000\n"
+"PO-Revision-Date: 2024-01-06 20:22+0200\n"
+"Last-Translator: volkov <volkovissocool@gmail.com>\n"
+"Language-Team: volkovissocool@gmail.com\n"
+"Language: ru_RU\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Poedit 3.4\n"
+
+#: src/main.rs:87
+msgid "Create A Distrobox"
+msgstr "Создать Distrobox"
+
+#: src/main.rs:110
+msgid "Distrobox not found!"
+msgstr "Distrobox не найден!"
+
+#: src/main.rs:114
+msgid "Distrobox could not be found, please ensure it is installed!"
+msgstr "Не удалось найти Distrobox - убедитесь, что эта программа установлена!"
+
+#: src/main.rs:199
+msgid "Open Terminal"
+msgstr "Открыть терминал"
+
+#: src/main.rs:211
+msgid "Upgrade Box"
+msgstr "Обновить коробку"
+
+#: src/main.rs:226
+msgid "View Applications"
+msgstr "Посмотреть приложения"
+
+#: src/main.rs:239
+msgid "Delete Box"
+msgstr "Удалить коробку"
+
+#: src/main.rs:263
+msgid "Create New Distrobox"
+msgstr "Создать новый Distrobox"
+
+#: src/main.rs:266
+msgid "Create"
+msgstr "Создать"
+
+#: src/main.rs:269 src/main.rs:518
+msgid "Cancel"
+msgstr "Отменить"
+
+#: src/main.rs:295
+msgid "Name"
+msgstr "Название"
+
+#: src/main.rs:307
+msgid "Image"
+msgstr "Образ"
+
+#: src/main.rs:408
+msgid "Installed Applications"
+msgstr "Установленный приложения"
+
+#: src/main.rs:417
+msgid "Loading..."
+msgstr "Загрузка..."
+
+#: src/main.rs:446
+msgid "No Applications Installed"
+msgstr "Никак приложений не установлено"
+
+#: src/main.rs:450
+msgid "Available Applications"
+msgstr "Доступные приложения"
+
+#: src/main.rs:461
+msgid "Add To Menu"
+msgstr "Добавить в меню"
+
+#: src/main.rs:475
+msgid "Run"
+msgstr "Запустить"
+
+#: src/main.rs:503
+msgid "App Exported!"
+msgstr "Приложение экспортировано!"
+
+#: src/main.rs:511
+msgid "Are you sure you want to delete "
+msgstr "Вы уверены, что хотите удалить "
+
+#: src/main.rs:514
+msgid "Really Delete?"
+msgstr "Действительно удалить?"
+
+#: src/main.rs:519
+msgid "Delete"
+msgstr "Удалить"
+
+#: src/main.rs:531
+msgid "Box Deleted!"
+msgstr "Коробка удалена!"
+
+#: src/main.rs:553
+msgid "Please install one of the supported terminals:"
+msgstr "Установите один из терминалов который поддерживается:"
+
+#: src/main.rs:557
+msgid "No supported terminal found"
+msgstr "Не найдено поддерживаемого терминала"
+
+#: src/main.rs:561
+msgid "Ok"
+msgstr "Хорошо"
+
+#: src/main.rs:573
+msgid "No Boxes"
+msgstr "Нет коробок"
+
+#: src/main.rs:575
+msgid "Click the + at the top-left to create your first box!"
+msgstr "Нажмите на + сверху-слева чтобы создать вашу первую коробку!"

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -1,6 +1,6 @@
 # Russian translation for BoxBuddy.
 # Copyright (C) 2024 THE BoxBuddy'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is distributed under the same license as the BoxBuddy package.
 # volkov <volkovissocool@gmail.com>, 2024.
 #
 msgid ""

--- a/po/uk_UA.po
+++ b/po/uk_UA.po
@@ -1,6 +1,6 @@
 # Ukrainian translation for BoxBuddy.
 # Copyright (C) 2024 THE BoxBuddy'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is distributed under the same license as the BoxBuddy package.
 # volkov <volkovissocool@gmail.com>, 2024.
 #
 msgid ""

--- a/po/uk_UA.po
+++ b/po/uk_UA.po
@@ -1,0 +1,131 @@
+# Ukrainian translation for BoxBuddy.
+# Copyright (C) 2024 THE BoxBuddy'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# volkov <volkovissocool@gmail.com>, 2024.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: DistroBuddy\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-06 13:06+0000\n"
+"PO-Revision-Date: 2024-01-06 20:18+0200\n"
+"Last-Translator: volkov <volkovissocool@gmail.com>\n"
+"Language-Team: volkovissocool@gmail.com\n"
+"Language: uk_UA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Poedit 3.4\n"
+
+#: src/main.rs:87
+msgid "Create A Distrobox"
+msgstr "Створити Distrobox"
+
+#: src/main.rs:110
+msgid "Distrobox not found!"
+msgstr "Distrobox не знайдено!"
+
+#: src/main.rs:114
+msgid "Distrobox could not be found, please ensure it is installed!"
+msgstr "Не вдалося знайти Distrobox - впевніться, що ця програма встановлена!"
+
+#: src/main.rs:199
+msgid "Open Terminal"
+msgstr "Відкрити термінал"
+
+#: src/main.rs:211
+msgid "Upgrade Box"
+msgstr "Оновити коробку"
+
+#: src/main.rs:226
+msgid "View Applications"
+msgstr "Переглянути додатки"
+
+#: src/main.rs:239
+msgid "Delete Box"
+msgstr "Видалити коробку"
+
+#: src/main.rs:263
+msgid "Create New Distrobox"
+msgstr "Створити новий Distrobox"
+
+#: src/main.rs:266
+msgid "Create"
+msgstr "Створити"
+
+#: src/main.rs:269 src/main.rs:518
+msgid "Cancel"
+msgstr "Скасувати"
+
+#: src/main.rs:295
+msgid "Name"
+msgstr "Назва"
+
+#: src/main.rs:307
+msgid "Image"
+msgstr "Образ"
+
+#: src/main.rs:408
+msgid "Installed Applications"
+msgstr "Встановлені додатки"
+
+#: src/main.rs:417
+msgid "Loading..."
+msgstr "Завантаження..."
+
+#: src/main.rs:446
+msgid "No Applications Installed"
+msgstr "Жодних додатків не встановлено"
+
+#: src/main.rs:450
+msgid "Available Applications"
+msgstr "Доступні додатки"
+
+#: src/main.rs:461
+msgid "Add To Menu"
+msgstr "Додати до меню"
+
+#: src/main.rs:475
+msgid "Run"
+msgstr "Запустити"
+
+#: src/main.rs:503
+msgid "App Exported!"
+msgstr "Додаток експортовано!"
+
+#: src/main.rs:511
+msgid "Are you sure you want to delete "
+msgstr "Ви впевнені що бажаєте видалити "
+
+#: src/main.rs:514
+msgid "Really Delete?"
+msgstr "Дійсно видалити?"
+
+#: src/main.rs:519
+msgid "Delete"
+msgstr "Видалити"
+
+#: src/main.rs:531
+msgid "Box Deleted!"
+msgstr "Коробка видалена!"
+
+#: src/main.rs:553
+msgid "Please install one of the supported terminals:"
+msgstr "Встановіть один із терміналів які підтримуються:"
+
+#: src/main.rs:557
+msgid "No supported terminal found"
+msgstr "Не знайдено термінал який підтримується"
+
+#: src/main.rs:561
+msgid "Ok"
+msgstr "Добре"
+
+#: src/main.rs:573
+msgid "No Boxes"
+msgstr "Немає коробок"
+
+#: src/main.rs:575
+msgid "Click the + at the top-left to create your first box!"
+msgstr "Клацніть на + зверху-зліва щоб створити вашу першу коробку!"


### PR DESCRIPTION
So, uh, I blindly added 2 translations, but I kind of unable to test them. I'm not rust user,  I don't know much about it's ecosystem and how to use it.
https://github.com/Dvlv/BoxBuddyRS/issues/6, here I mentioned Resources, where they using meson build system, which means it enable easy support for GNOME Builder, allowing translators to click "Run" button and test their translations.

Since this is not case here, I tried to use this cargo to build and run, but seems that fedora 39 uses outdated dependencies for gtk and other components, so cargo unable build anything.

Maybe you will consider moving building process to meson in future? You can do same for pot generation script.

Also, in future you might want to add more context and hint information in translations. For example, it was unclear what "Image" means. Does image as picture or as system image?