### PR TITLE
Specify custom home when creating a new distrobox container

### DIFF
--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -230,10 +230,15 @@ pub fn delete_box(box_name: String) -> String {
     get_command_output(String::from("distrobox"), Some(&["rm", &box_name, "-f"]))
 }
 
-pub fn create_box(box_name: String, image: String) -> String {
+pub fn create_box(box_name: String, image: String, home_path: String) -> String {
     let mut args = vec!["create", "-n", &box_name, "-i", &image, "-Y"];
     if is_nvidia() {
         args.push("--nvidia");
+    }
+
+    if !home_path.is_empty() {
+        args.push("--home");
+        args.push(&home_path);
     }
 
     get_command_output(String::from("distrobox"), Some(args.as_slice()))


### PR DESCRIPTION
Hello there, I'd like to contribute the feature in #21 and on the roadmap to specify custom home directoies when creating a new distrobox container.

![Bildschirmfoto vom 2024-01-18 14-01-24](https://github.com/Dvlv/BoxBuddyRS/assets/11244092/804172d4-dd07-475c-91cb-8dbd449b5e12)

In the new container view I added a new ActionRow containing an EntryRow and a button which will open up a directory chooser using FileDialog (FileChooser etc are deprecated by GTK4 / Adw so I did not used those).
After selecting a directory the selected path will be set as the text of the EntryRow allowing for the user to manually edit the chosen directory without the need to open the FileDialog again.

If the EntryRow is empty the --home parameter will not be added to the distrobox-create args hence the default by distrobox will be used.

Before `create_box` is called in the home path all spaces will be replaced with backslash space to avoid incomplete directories being passed to distrobox create.

I'd like to note I am not very fluent in Rust and kinda happy it worked in the first place 😆 please feel free to suggest any changes especially on how to do certain thing in Rust and which don't. 

I appreciate your feedback.

Kind regards,  
V.