### PR TITLE
Add support for distrobox assemble

### DIFF
--- a/io.github.dvlv.boxbuddyrs.metainfo.xml
+++ b/io.github.dvlv.boxbuddyrs.metainfo.xml
@@ -35,6 +35,12 @@
     <url type="homepage">https://github.com/Dvlv/BoxBuddyRS</url>
 
     <releases>
+        <release version="1.2.1" date="2024-02-02">
+            <description>
+                <p>Added support for GNOME Console</p>
+                <p>Added an info button letting Flatpak users know how to enable Custom Home Directory support</p>
+            </description>
+        </release>
         <release version="1.2.0" date="2024-01-29">
             <description>
                 <p>Added the ability to create a box with an init system</p>

--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -253,6 +253,11 @@ pub fn create_box(box_name: String, image: String, home_path: String, use_init: 
     get_command_output(String::from("distrobox"), Some(args.as_slice()))
 }
 
+pub fn assemble_box(ini_file: String) -> String {
+    let mut args = vec!["assemble", "create", "--file", &ini_file];
+    get_command_output(String::from("distrobox"), Some(args.as_slice()))
+}
+
 pub fn get_available_images_with_distro_name() -> Vec<String> {
     let existing_images = get_repository_list();
     let output = get_command_output(String::from("distrobox"), Some(&["create", "-C"]));

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,27 +87,29 @@ fn make_titlebar(window: &ApplicationWindow) {
     add_btn.connect_clicked(move |_btn| create_new_distrobox(&win_clone));
 
     let assemble_btn = gtk::Button::from_icon_name("document-properties-symbolic");
-    // TRANSLATORS: Button tooltip
-    assemble_btn.set_tooltip_text(Some(&gettext("Assemble A Distrobox")));
+    if has_host_access() {
+        // TRANSLATORS: Button tooltip
+        assemble_btn.set_tooltip_text(Some(&gettext("Assemble A Distrobox")));
 
-    let win_clone_assemble = window.clone();
-    assemble_btn.connect_clicked(clone!(@weak window => move |_btn| {
-        let ini_filter = gtk::FileFilter::new();
+        let win_clone_assemble = window.clone();
+        assemble_btn.connect_clicked(clone!(@weak window => move |_btn| {
+            let ini_filter = gtk::FileFilter::new();
 
-        //TRANSLATORS: File type
-        ini_filter.set_name(Some(&gettext("INI-Files")));
-        ini_filter.add_mime_type("text/plain".as_ref());
-        ini_filter.add_mime_type("application/textedit".as_ref());
-        ini_filter.add_mime_type("application/zz-winassoc-ini".as_ref());
+            //TRANSLATORS: File type
+            ini_filter.set_name(Some(&gettext("INI-Files")));
+            ini_filter.add_mime_type("text/plain".as_ref());
+            ini_filter.add_mime_type("application/textedit".as_ref());
+            ini_filter.add_mime_type("application/zz-winassoc-ini".as_ref());
 
-        let file_dialog = FileDialog::builder().default_filter(&ini_filter).modal(false).build();
-        file_dialog.open(Some(&window), None::<&gio::Cancellable>, clone!(@weak window => move |result| {
-            if let Ok(file) = result {
-                let ini_path = file.path().unwrap().into_os_string().into_string().unwrap();
-                assemble_new_distrobox(&window, ini_path);
-            }
+            let file_dialog = FileDialog::builder().default_filter(&ini_filter).modal(false).build();
+            file_dialog.open(Some(&window), None::<&gio::Cancellable>, clone!(@weak window => move |result| {
+                if let Ok(file) = result {
+                    let ini_path = file.path().unwrap().into_os_string().into_string().unwrap();
+                    assemble_new_distrobox(&window, ini_path);
+                }
+            }));
         }));
-    }));
+    }
 
     let about_btn = gtk::Button::from_icon_name("help-about-symbolic");
     // TRANSLATORS: Button tooltip
@@ -131,7 +133,9 @@ fn make_titlebar(window: &ApplicationWindow) {
     let titlebar = adw::HeaderBar::builder().title_widget(&title_lbl).build();
 
     titlebar.pack_start(&add_btn);
-    titlebar.pack_start(&assemble_btn);
+    if has_host_access() {
+        titlebar.pack_start(&assemble_btn);
+    }
     titlebar.pack_end(&about_btn);
     titlebar.pack_end(&refresh_btn);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -481,7 +481,7 @@ fn show_about_popup(window: &ApplicationWindow) {
     let d = adw::AboutWindow::new();
     d.set_transient_for(Some(window));
     d.set_application_name("BoxBuddy");
-    d.set_version("1.2.0");
+    d.set_version("1.2.1");
     d.set_developer_name("Dvlv");
     d.set_license_type(gtk::License::MitX11);
     d.set_comments(


### PR DESCRIPTION
# About
While working on the volumes feature (still very WIP) I also noticed we have no support for distrobox assemble files.  
Typically those are ini files containing one or more distrobox specifications.

An example could look like this:

```
[tumbleweed-test]
additional_packages=git bash-completion opi ffmpeg-6 gcc make cmake htop scout-command-not-found
image=tumbleweed:latest
init=true
start_now=false
nvidia=true
pull=true
root=false
replace=false
volume=/opt/datalake:/opt/datalake
volume=/etc/vulkan/:/etc/vulkan/

[rocky-test]
additional_packages=fuse fuse-libs alsa-lib apr apr-util fontconfig freetype libglvnd libglvnd-egl libglvnd-glx libglvnd-opengl libgomp librsvg2 libXcursor libXfixes libXi libXinerama libxkbcommon libxkbcommon-x11 libXrandr libXrender libXtst libXxf86vm mesa-libGLU mtdev pulseaudio-libs xcb-util xcb-util-image xcb-util-keysyms xcb-util-renderutil xcb-util-wm ocl-icd
image=quay.io/rockylinux/rockylinux:8
pull=true
replace=true
nvidia=true

[appimage-test]
additional_packages=fuse libfuse2 xcb libfontconfig1 libxcb-xkb1 libxkbcommon-x11-0 libXi6 libXrender1 libQt5WaylandClient5 libqt5-qtwayland libQt6WaylandClient6 kwayland qt6-wayland pipewire-alsa libfribidi0 libthai libXtst6
image=tumbleweed:latest
init=false
start_now=false
nvidia=true
pull=true
root=false
replace=true
```

With the command `distrobox assemble --file /path/to/file` distrobox can created one ore more distroboxes at once.  

I added a new button to the header bar for the assemble feature instead of adding it to the new distrobox popup because I found the assemble feature rather different from the create feature.  
This button will only show if host_access is true for flatpak users.  

![Bildschirmfoto vom 2024-02-03 12-24-37](https://github.com/Dvlv/BoxBuddyRS/assets/11244092/e53a7b35-0653-4397-bb0b-1c5551a06a09)

Clicking this button will open up a FileDialog with a file filter for the MIME-Types: text/plain, application/textedit and application/zz-winassoc-ini

![Bildschirmfoto vom 2024-02-03 12-42-33](https://github.com/Dvlv/BoxBuddyRS/assets/11244092/483cfc61-ebbf-4315-8f64-1ec4ec058543)

Then a popup will shown with a status message and a spinner as long as distrobox is busy which will then auto close and trigger a re render of the main window to show the new boxes.

![Bildschirmfoto vom 2024-02-03 12-42-36](https://github.com/Dvlv/BoxBuddyRS/assets/11244092/d61c65cc-7ca0-4df7-8600-133fce212451)

![Bildschirmfoto vom 2024-02-03 12-42-43](https://github.com/Dvlv/BoxBuddyRS/assets/11244092/33ab3dee-02b3-43ba-87e3-65bb20138b13)

I did not yet provided any additional translations for this new feature as I plan on adding all missing translations later if more stuff was added.

**Notice:** The user would be able to create distrobox containers without nvidia integration this way!  
But also I assume user to have those ini files do also know about the nvidia flag.

Kind regards,
V.