### PR TITLE
Fix assemble icon for dark mode

### DIFF
--- a/icons/build-alt-symbolic-light.svg
+++ b/icons/build-alt-symbolic-light.svg
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16px"
+   viewBox="0 0 16 16"
+   width="16px"
+   version="1.1"
+   id="svg13"
+   sodipodi:docname="build-alt-symbolic-light.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs13">
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Invert"
+       id="filter13"
+       x="0"
+       y="0"
+       width="1"
+       height="1">
+      <feColorMatrix
+         values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 -0.21 -0.72 -0.07 2 0 "
+         result="fbSourceGraphic"
+         id="feColorMatrix13" />
+      <feColorMatrix
+         result="fbSourceGraphicAlpha"
+         in="fbSourceGraphic"
+         values="0 0 0 -1 0 0 0 0 -1 0 0 0 0 -1 0 0 0 0 1 0"
+         id="feColorMatrix14" />
+      <feColorMatrix
+         id="feColorMatrix15"
+         type="hueRotate"
+         values="180"
+         result="color1"
+         in="fbSourceGraphic" />
+      <feColorMatrix
+         id="feColorMatrix16"
+         values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 -0.21 -0.72 -0.07 2 0 "
+         result="fbSourceGraphic" />
+      <feColorMatrix
+         result="fbSourceGraphicAlpha"
+         in="fbSourceGraphic"
+         values="0 0 0 -1 0 0 0 0 -1 0 0 0 0 -1 0 0 0 0 1 0"
+         id="feColorMatrix17" />
+      <feColorMatrix
+         id="feColorMatrix18"
+         type="hueRotate"
+         values="180"
+         result="color1"
+         in="fbSourceGraphic" />
+      <feColorMatrix
+         id="feColorMatrix19"
+         values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 -0.21 -0.72 -0.07 2 0 "
+         result="fbSourceGraphic" />
+      <feColorMatrix
+         result="fbSourceGraphicAlpha"
+         in="fbSourceGraphic"
+         values="0 0 0 -1 0 0 0 0 -1 0 0 0 0 -1 0 0 0 0 1 0"
+         id="feColorMatrix20" />
+      <feColorMatrix
+         id="feColorMatrix21"
+         values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 -0.21 -0.72 -0.07 2 0 "
+         result="color2"
+         in="fbSourceGraphic" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="namedview13"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="50.3125"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg13" />
+  <filter
+     id="a"
+     height="1"
+     width="1"
+     x="0"
+     y="0">
+    <feColorMatrix
+       color-interpolation-filters="sRGB"
+       values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 1 0"
+       id="feColorMatrix1" />
+  </filter>
+  <mask
+     id="b">
+    <g
+       filter="url(#a)"
+       id="g1">
+      <path
+         d="m -1.6 -1.6 h 19.2 v 19.2 h -19.2 z"
+         fill-opacity="0.5"
+         id="path1" />
+    </g>
+  </mask>
+  <clipPath
+     id="c">
+    <path
+       d="m 0 0 h 1600 v 1200 h -1600 z"
+       id="path2" />
+  </clipPath>
+  <mask
+     id="d">
+    <g
+       filter="url(#a)"
+       id="g3">
+      <path
+         d="m -1.6 -1.6 h 19.2 v 19.2 h -19.2 z"
+         fill-opacity="0.7"
+         id="path3" />
+    </g>
+  </mask>
+  <clipPath
+     id="e">
+    <path
+       d="m 0 0 h 1600 v 1200 h -1600 z"
+       id="path4" />
+  </clipPath>
+  <mask
+     id="f">
+    <g
+       filter="url(#a)"
+       id="g5">
+      <path
+         d="m -1.6 -1.6 h 19.2 v 19.2 h -19.2 z"
+         fill-opacity="0.35"
+         id="path5" />
+    </g>
+  </mask>
+  <clipPath
+     id="g">
+    <path
+       d="m 0 0 h 1600 v 1200 h -1600 z"
+       id="path6" />
+  </clipPath>
+  <path
+     d="M 10.785156,1.082031 C 11.34375,1.59375 12.007812,2.289062 12.964844,3.25 c 0.28125,0.28125 0.390625,0.746094 0.175781,1.246094 -0.09766,0.25 -0.03906,0.53125 0.152344,0.71875 0.261719,0.253906 0.679687,0.253906 0.945312,0 C 14.5,4.953125 15.03125,5.128906 15.160156,5.257812 l 0.480469,0.480469 v -0.00391 c 0.394531,0.390625 0.394531,1.027344 0,1.417969 l -2.363281,2.367187 c -0.390625,0.390625 -1.027344,0.390625 -1.417969,0 L 11.398438,8.996094 c -0.261719,-0.261719 -0.261719,-0.683594 0,-0.945313 0.261718,-0.261719 0.261718,-0.683593 0,-0.945312 C 11.136719,6.851562 10.652344,6.808594 10.386719,7.0625 L 9.214844,8.167969 6.773438,5.722656 c 0,0 0.839843,-0.828125 1.085937,-1.066406 C 8.476562,4.03125 7.921875,3.503906 7.648438,3.238281 6.984375,2.578125 5.609375,2.316406 4.671875,2.355469 4.378906,2.367188 4.113281,2.1875 4.011719,1.914062 3.914062,1.636719 4.007812,1.328125 4.246094,1.152344 7,-0.0078125 9.699219,-0.0078125 10.785156,1.082031 Z M 8.335938,9.117188 3.046875,14.394531 c -0.371094,0.375 -0.671875,0.625 -1.019531,0.625 -1.089844,-0.02734 -1.9726565,-0.910156 -2.0000002,-2 0,-0.53125 0.1289062,-0.726562 0.5039062,-1.097656 L 5.828125,6.648438 Z m 0,0"
+     fill="#222222"
+     id="path7"
+     style="display:inline;filter:url(#filter13)" />
+</svg>

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
 use gettextrs::*;
 use std::thread;
 
-use adw::{prelude::{ActionRowExt, MessageDialogExt, PreferencesRowExt}, ActionRow, Application, ToastOverlay, StyleManager};
+use adw::{
+    prelude::{ActionRowExt, MessageDialogExt, PreferencesRowExt},
+    ActionRow, Application, StyleManager, ToastOverlay,
+};
 use gtk::{gio, glib::*, prelude::*, FileDialog};
 use gtk::{
     glib::{self},
@@ -12,12 +15,12 @@ mod distrobox_handler;
 use distrobox_handler::*;
 
 mod utils;
+use crate::utils::get_assemble_icon;
 use utils::{
     get_distro_img, get_icon_file_path, get_supported_terminals_list,
     get_terminal_and_separator_arg, has_distrobox_installed, has_host_access, is_dark_mode,
     set_up_localisation,
 };
-use crate::utils::get_assemble_icon;
 
 const APP_ID: &str = "io.github.dvlv.boxbuddyrs";
 
@@ -93,7 +96,7 @@ fn make_titlebar(window: &ApplicationWindow) {
 
     let style_manager = StyleManager::default();
     let assemble_btn_clone = assemble_btn.clone();
-    style_manager.connect_dark_notify(move |_btn|{
+    style_manager.connect_dark_notify(move |_btn| {
         let icon_path = get_assemble_icon();
         let new_image = gtk::Image::from_file(icon_path);
         assemble_btn_clone.set_child(Some(&new_image));

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,9 @@ fn make_titlebar(window: &ApplicationWindow) {
 
     let assemble_btn = gtk::Button::new();
     let icon_path = get_assemble_icon();
+    let build_img = gtk::Image::from_file(icon_path);
+    assemble_btn.set_child(Some(&build_img));
+    assemble_btn.add_css_class("flat");
 
     let style_manager = StyleManager::default();
     let assemble_btn_clone = assemble_btn.clone();
@@ -101,10 +104,6 @@ fn make_titlebar(window: &ApplicationWindow) {
         let new_image = gtk::Image::from_file(icon_path);
         assemble_btn_clone.set_child(Some(&new_image));
     });
-
-    let build_img = gtk::Image::from_file(icon_path);
-    assemble_btn.set_child(Some(&build_img));
-    assemble_btn.add_css_class("flat");
 
     if has_host_access() {
         // TRANSLATORS: Button tooltip

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,9 @@ use distrobox_handler::*;
 
 mod utils;
 use utils::{
-    get_distro_img, get_icon_file_path, get_supported_terminals_list, is_dark_mode,
-    get_terminal_and_separator_arg, has_distrobox_installed, has_host_access, set_up_localisation,
+    get_distro_img, get_icon_file_path, get_supported_terminals_list,
+    get_terminal_and_separator_arg, has_distrobox_installed, has_host_access, is_dark_mode,
+    set_up_localisation,
 };
 
 const APP_ID: &str = "io.github.dvlv.boxbuddyrs";
@@ -682,7 +683,9 @@ fn show_about_popup(window: &ApplicationWindow) {
     d.set_support_url("https://dvlv.github.io/BoxBuddyRS");
     d.set_developers(&["Dvlv", "VortexAcherontic"]);
     d.set_application_icon("io.github.dvlv.boxbuddyrs");
-    d.set_translator_credits("Vovkiv - RU and UK\nalbanobattistella - IT\nVortexAcherontic - DE\nLuiz-C-Lima - pt_BR");
+    d.set_translator_credits(
+        "Vovkiv - RU and UK\nalbanobattistella - IT\nVortexAcherontic - DE\nLuiz-C-Lima - pt_BR",
+    );
     d.present();
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,7 @@
 use gettextrs::*;
 use std::thread;
 
-use adw::{
-    prelude::{ActionRowExt, MessageDialogExt, PreferencesRowExt},
-    ActionRow, Application, ToastOverlay,
-};
+use adw::{prelude::{ActionRowExt, MessageDialogExt, PreferencesRowExt}, ActionRow, Application, ToastOverlay, StyleManager};
 use gtk::{gio, glib::*, prelude::*, FileDialog};
 use gtk::{
     glib::{self},
@@ -20,6 +17,7 @@ use utils::{
     get_terminal_and_separator_arg, has_distrobox_installed, has_host_access, is_dark_mode,
     set_up_localisation,
 };
+use crate::utils::get_assemble_icon;
 
 const APP_ID: &str = "io.github.dvlv.boxbuddyrs";
 
@@ -90,12 +88,18 @@ fn make_titlebar(window: &ApplicationWindow) {
     let win_clone = window.clone();
     add_btn.connect_clicked(move |_btn| create_new_distrobox(&win_clone));
 
-    let mut icon_path = get_icon_file_path("build-alt-symbolic.svg".to_owned());
-    if is_dark_mode() {
-        icon_path = get_icon_file_path("build-alt-symbolic-light.svg".to_owned());
-    }
-    let build_img = gtk::Image::from_file(icon_path);
     let assemble_btn = gtk::Button::new();
+    let icon_path = get_assemble_icon();
+
+    let style_manager = StyleManager::default();
+    let assemble_btn_clone = assemble_btn.clone();
+    style_manager.connect_dark_notify(move |_btn|{
+        let icon_path = get_assemble_icon();
+        let new_image = gtk::Image::from_file(icon_path);
+        assemble_btn_clone.set_child(Some(&new_image));
+    });
+
+    let build_img = gtk::Image::from_file(icon_path);
     assemble_btn.set_child(Some(&build_img));
     assemble_btn.add_css_class("flat");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use distrobox_handler::*;
 
 mod utils;
 use utils::{
-    get_distro_img, get_icon_file_path, get_supported_terminals_list,
+    get_distro_img, get_icon_file_path, get_supported_terminals_list, is_dark_mode,
     get_terminal_and_separator_arg, has_distrobox_installed, has_host_access, set_up_localisation,
 };
 
@@ -89,7 +89,10 @@ fn make_titlebar(window: &ApplicationWindow) {
     let win_clone = window.clone();
     add_btn.connect_clicked(move |_btn| create_new_distrobox(&win_clone));
 
-    let icon_path = get_icon_file_path("build-alt-symbolic.svg".to_owned());
+    let mut icon_path = get_icon_file_path("build-alt-symbolic.svg".to_owned());
+    if is_dark_mode() {
+        icon_path = get_icon_file_path("build-alt-symbolic-light.svg".to_owned());
+    }
     let build_img = gtk::Image::from_file(icon_path);
     let assemble_btn = gtk::Button::new();
     assemble_btn.set_child(Some(&build_img));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,6 +3,9 @@ use std::collections::HashMap;
 use std::env;
 use std::path::Path;
 use std::process::Command;
+use adw::gio::Settings;
+use adw::StyleManager;
+use crate::APP_ID;
 
 pub fn run_command(
     cmd_to_run: std::string::String,
@@ -327,11 +330,22 @@ pub fn get_icon_file_path(icon: String) -> String {
         return format!("/app/icons/{}", icon);
     }
 
-    // Developers, uncomment this for testing
-    //return format!("icons/{}", icon);
+    /*
+    If build without optimizations this will usually be executed
+    during development aka cargo run or plain cargo build
+     */
+    debug_assert!({
+        return format!("icons/{}", icon);
+    });
+
     let home_dir = env::var("HOME").unwrap_or_else(|_| ".".to_string());
     let data_home =
         env::var("XDG_DATA_HOME").unwrap_or_else(|_| format!("{home_dir}/.local/share"));
 
     format!("{data_home}/icons/boxbuddy/{}", icon)
+}
+
+pub fn is_dark_mode() -> bool {
+    let user_settings = StyleManager::default();
+    return user_settings.is_dark();
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -352,6 +352,5 @@ pub fn get_assemble_icon() -> String {
 }
 
 pub fn is_dark_mode() -> bool {
-    let user_settings = StyleManager::default();
-    return user_settings.is_dark();
+    return StyleManager::default().is_dark();
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -344,11 +344,10 @@ pub fn get_icon_file_path(icon: String) -> String {
 }
 
 pub fn get_assemble_icon() -> String {
-    let mut icon_path = get_icon_file_path("build-alt-symbolic.svg".to_owned());
     if is_dark_mode() {
-        icon_path = get_icon_file_path("build-alt-symbolic-light.svg".to_owned());
+        return get_icon_file_path("build-alt-symbolic-light.svg".to_owned());
     }
-    return icon_path;
+    return get_icon_file_path("build-alt-symbolic.svg".to_owned());
 }
 
 pub fn is_dark_mode() -> bool {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,3 @@
-use crate::APP_ID;
-use adw::gio::Settings;
 use adw::StyleManager;
 use gettextrs::*;
 use std::collections::HashMap;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -343,7 +343,7 @@ pub fn get_icon_file_path(icon: String) -> String {
     format!("{data_home}/icons/boxbuddy/{}", icon)
 }
 
-pub fn get_assemble_icon() -> String{
+pub fn get_assemble_icon() -> String {
     let mut icon_path = get_icon_file_path("build-alt-symbolic.svg".to_owned());
     if is_dark_mode() {
         icon_path = get_icon_file_path("build-alt-symbolic-light.svg".to_owned());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,11 @@
+use crate::APP_ID;
+use adw::gio::Settings;
+use adw::StyleManager;
 use gettextrs::*;
 use std::collections::HashMap;
 use std::env;
 use std::path::Path;
 use std::process::Command;
-use adw::gio::Settings;
-use adw::StyleManager;
-use crate::APP_ID;
 
 pub fn run_command(
     cmd_to_run: std::string::String,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -343,6 +343,14 @@ pub fn get_icon_file_path(icon: String) -> String {
     format!("{data_home}/icons/boxbuddy/{}", icon)
 }
 
+pub fn get_assemble_icon() -> String{
+    let mut icon_path = get_icon_file_path("build-alt-symbolic.svg".to_owned());
+    if is_dark_mode() {
+        icon_path = get_icon_file_path("build-alt-symbolic-light.svg".to_owned());
+    }
+    return icon_path;
+}
+
 pub fn is_dark_mode() -> bool {
     let user_settings = StyleManager::default();
     return user_settings.is_dark();


### PR DESCRIPTION
Hello there,

Since BoxBuddy uses a custom hammer icon for the distrobox assemble button it only comes with a dark variant.  
This one does not line up with the dark mode of Gnome.

By this PR I introduced a util function `is_dark_mode()` which uses the Adwaita StyleManager to check if the desktop is running with a dark or a light theme.  

In addition I provided a light version of the hammer icon which is then used for the button instead of the dark variant.

Edit: Forgot to mention this.  
I also added:

```
    debug_assert!({
        return format!("icons/{}", icon);
    });
```
for the icon path for development environments.  
This code is only executed if BoxBuddy is compiled without optimizations.  
In order for developers not needing to uncomment the icon path for development purpose.  
For further details I leave the link to the official documentation [here](https://doc.rust-lang.org/std/macro.debug_assert.html)


Kind regards,
V.