### PR TITLE
Minor refactor for volumes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -663,9 +663,11 @@ fn create_new_distrobox(window: &ApplicationWindow) {
 
         let mut volumes: Vec<String> = vec![];
         if volume_box_list_clone.is_visible() {
-            while let Some(row) = volume_box_list_clone.last_child() {
-                let entry_row = row
-                    .first_child()
+            let mut index = 0;
+            let mut row = volume_box_list_clone.row_at_index(index);
+            while row != None {
+                let entry_row = row.clone()
+                    .unwrap().first_child()
                     .unwrap()
                     .first_child()
                     .unwrap()
@@ -673,10 +675,10 @@ fn create_new_distrobox(window: &ApplicationWindow) {
                     .unwrap()
                     .downcast::<adw::EntryRow>()
                     .unwrap();
-
                 let volume_arg = format!("{}:{}", entry_row.title(), entry_row.text());
                 volumes.push(volume_arg);
-                volume_box_list_clone.remove(&row);
+                index += 1;
+                row = volume_box_list_clone.row_at_index(index);
             }
         }
 


### PR DESCRIPTION
Hey there, this is just a very very small PR but a sting in my eye since I added this feature 😆 

Before BoxBuddy iterated over the ListBox containing all volumes simply by removing the last row until no row was present any more.
This could be observed by the user while looking at all those little volume entries to disappear one by one.

The refactored code now works a little different. It simply fetches the first row at index 0. If it is `None` it will continue as no volumes has been set. 
If it is not `None` it then does the usual unwrap and downcast to get the actual volume host and volume guest paths.
Then it will recursively fetch the following rows and do the same. Until `None` is received. At that point all rows have been iterated and added to the volume vec.

This fixes the dissolving volume entry rows.

Kind regards,
V.