### PR TITLE
Add support for Ptyxis terminal

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -9,6 +9,7 @@ Some features require filesystem access, which is not granted by default. Please
 ## What terminals are supported?
 BoxBuddy will try to spawn the following terminals, in the following order:
 
+- Ptyxis
 - GNOME Console
 - GNOME Terminal
 - Konsole

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -178,6 +178,11 @@ pub fn has_distrobox_installed() -> bool {
 pub fn get_supported_terminals() -> Vec<TerminalOption> {
     vec![
         TerminalOption {
+            name: String::from("Ptyxis"),
+            executable_name: String::from("ptyxis"),
+            separator_arg: String::from("--"),
+        },
+        TerminalOption {
             name: String::from("GNOME Console"),
             executable_name: String::from("kgx"),
             separator_arg: String::from("--"),


### PR DESCRIPTION
Ptyxis is a new GNOME terminal from Christian Hergert that offers first-class support for containers.
https://gitlab.gnome.org/chergert/ptyxis

This PR adds it as the 1st choice given it's container-oriented feature set, but if you'd like that changed just let me know :)

![image](https://github.com/Dvlv/BoxBuddyRS/assets/10704358/6a397149-4926-4c04-ab6c-90bdf5f1eb09)
