### PR TITLE
Dekstop: Add keywords for easier discovery

### DIFF
--- a/io.github.dvlv.boxbuddyrs.desktop
+++ b/io.github.dvlv.boxbuddyrs.desktop
@@ -4,5 +4,6 @@ Exec=boxbuddy-rs
 Type=Application
 Icon=io.github.dvlv.boxbuddyrs
 Categories=Utility;
+Keywords=container;podman;distrobox;
 Comment=A Graphical Application For Managing Distroboxes
 MimeType=application/x-rpm;application/vnd.debian.binary-package


### PR DESCRIPTION
With a few keywords like these, it would be easier for end-users to find what they're looking for on the desktop.