### PR TITLE
Misc quality fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,5 +36,8 @@ version-check:
 translate:
 	bash scripts/compile-translations.sh
 
+update-translations:
+	bash scripts/update-translations.sh
+
 f40:
 	GETTEXT_SYSTEM=true cargo build --release

--- a/docs/translator-docs.md
+++ b/docs/translator-docs.md
@@ -14,3 +14,8 @@ To translate BoxBuddy, please follow these instructions:
 - Open up `src/utils.rs` and find the comment which starts with `--TRANSLATORS:`
 - Comment out the if/else statement below by adding `//` to the start of the lines
 - Run `cargo run` as normal
+
+## Updating a `po` file from a new `pot` file
+
+To avoid having to manually rebase your `po` files each time the `pot` file changes (for example
+when all the line numbers change), you can simply run `make update-translations`.

--- a/po/boxbuddy.pot
+++ b/po/boxbuddy.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-13 08:56+0000\n"
+"POT-Creation-Date: 2024-06-14 07:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,167 +18,167 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:139
+#: src/main.rs:150
 msgid "Create A Distrobox"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:158
+#: src/main.rs:169
 msgid "Assemble A Distrobox"
 msgstr ""
 
 #. TRANSLATORS: File type
-#: src/main.rs:164
+#: src/main.rs:175
 msgid "INI-Files"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:185
+#: src/main.rs:196
 msgid "Menu"
 msgstr ""
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:238
+#: src/main.rs:249
 msgid "Refresh"
 msgstr ""
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:244
+#: src/main.rs:255
 msgid "Set Preferred Terminal"
 msgstr ""
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:251
+#: src/main.rs:262
 msgid "About BoxBuddy"
 msgstr ""
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:256
+#: src/main.rs:267
 msgid "Quit"
 msgstr ""
 
 #. TRANSLATORS: Error message
-#: src/main.rs:264
+#: src/main.rs:275
 msgid "Distrobox not found!"
 msgstr ""
 
 #. TRANSLATORS: Error message
-#: src/main.rs:269
+#: src/main.rs:280
 msgid "Distrobox could not be found, please ensure it is installed!"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:341
+#: src/main.rs:352
 msgid "Stop Box"
 msgstr ""
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:370
+#: src/main.rs:381
 msgid "Open Terminal"
 msgstr ""
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:383
+#: src/main.rs:394
 msgid "Upgrade Box"
 msgstr ""
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:395
+#: src/main.rs:406
 msgid "View Applications"
 msgstr ""
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:418
+#: src/main.rs:429
 msgid "Delete Box"
 msgstr ""
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:431
+#: src/main.rs:442
 msgid "Clone Box"
 msgstr ""
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:451
+#: src/main.rs:462
 msgid "Install .deb File"
 msgstr ""
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:463
+#: src/main.rs:474
 msgid "Install .rpm File"
 msgstr ""
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:512 src/main.rs:570
+#: src/main.rs:523 src/main.rs:581
 msgid "Create New Distrobox"
 msgstr ""
 
 #. TRANSLATORS: Context label of the application doing something
-#: src/main.rs:524
+#: src/main.rs:535
 msgid "Assembling Distroboxes, please wait..."
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:578
+#: src/main.rs:589
 msgid "Create"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:583
+#: src/main.rs:594
 msgid "Additional Information"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:588 src/main.rs:1059 src/main.rs:1104 src/main.rs:1334 src/main.rs:1549
+#: src/main.rs:599 src/main.rs:1078 src/main.rs:1123 src/main.rs:1353 src/main.rs:1568
 msgid "Cancel"
 msgstr ""
 
 #. TRANSLATORS: Entry Label - Name input for new distrobox
-#: src/main.rs:622 src/main.rs:1142
+#: src/main.rs:633 src/main.rs:1161
 msgid "Name"
 msgstr ""
 
 #. TRANSLATORS: Entry Label - Select home directory for new distrobox
-#: src/main.rs:643
+#: src/main.rs:654
 msgid "Home Directory (Leave blank for default)"
 msgstr ""
 
 #. TRANSLATORS - Label for Dropdown where the user selects the container image to create
-#: src/main.rs:676
+#: src/main.rs:687
 msgid "Image"
 msgstr ""
 
 #. TRANSLATORS - Label for Toggle when creating box to add systemd support
-#: src/main.rs:683
+#: src/main.rs:694
 msgid "Use init system"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:790
+#: src/main.rs:801
 msgid "Add a volume"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:803
+#: src/main.rs:814
 msgid "Remove volume"
 msgstr ""
 
 #. TRANSLATORS: Help text for volume input
-#: src/main.rs:816
+#: src/main.rs:827
 msgid "Enter the location to mount this folder inside your new box"
 msgstr ""
 
 #. TRANSLATORS: Subheading
-#: src/main.rs:840
+#: src/main.rs:851
 msgid "Additional Volumes:"
 msgstr ""
 
 #. TRANSLATORS: Context for the Additional Volumes subheading
-#: src/main.rs:843
+#: src/main.rs:854
 msgid "Additional directories the new box should be able to access"
 msgstr ""
 
 #. TRANSLATORS: Description of the application
-#: src/main.rs:867
+#: src/main.rs:878
 msgid "A Graphical Manager for your Distroboxes.\n"
 "    \n"
 "BoxBuddy is not partnered with or endorsed by any linux distributions or companies.\n"
@@ -187,219 +187,219 @@ msgid "A Graphical Manager for your Distroboxes.\n"
 msgstr ""
 
 #. TRANSLATORS: Window Title - shows list of installed applications in distrobox
-#: src/main.rs:893
+#: src/main.rs:912
 msgid "Installed Applications"
 msgstr ""
 
 #. TRANSLATORS: Loading Message
-#: src/main.rs:911
+#: src/main.rs:930
 msgid "Loading..."
 msgstr ""
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:954
+#: src/main.rs:973
 msgid "No Applications Installed"
 msgstr ""
 
 #. TRANSLATORS: Window Title
-#: src/main.rs:959
+#: src/main.rs:978
 msgid "Available Applications"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:972
+#: src/main.rs:991
 msgid "Run"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:988
+#: src/main.rs:1007
 msgid "Remove From Menu"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1005
+#: src/main.rs:1024
 msgid "Add To Menu"
 msgstr ""
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1036
+#: src/main.rs:1055
 msgid "App Exported!"
 msgstr ""
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1042
+#: src/main.rs:1061
 msgid "App Removed!"
 msgstr ""
 
 #. TRANSLATORS: Confirmation Dialogue
-#: src/main.rs:1053
+#: src/main.rs:1072
 msgid "Really Delete?"
 msgstr ""
 
 #. TRANSLATORS: Confirmation Dialogue - {} replaced with the name of the Distrobox
-#: src/main.rs:1055
+#: src/main.rs:1074
 msgid "Are you sure you want to delete {}?"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1061
+#: src/main.rs:1080
 msgid "Delete"
 msgstr ""
 
 #. TRANSLATORS: Success Text
-#: src/main.rs:1074
+#: src/main.rs:1093
 msgid "Box Deleted!"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1096 src/main.rs:1100
+#: src/main.rs:1115 src/main.rs:1119
 msgid "Clone"
 msgstr ""
 
 #. TRANSLATORS: Title / Instruction label
-#: src/main.rs:1126
+#: src/main.rs:1145
 msgid "Enter the name of your new box"
 msgstr ""
 
-#: src/main.rs:1130
+#: src/main.rs:1149
 msgid "Note: Cloning can take a long time, please be patient"
 msgstr ""
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1211
+#: src/main.rs:1230
 msgid "Please install one of the supported terminals:"
 msgstr ""
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1216
+#: src/main.rs:1235
 msgid "No supported terminal found"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1221 src/main.rs:1259 src/main.rs:1277 src/main.rs:1313 src/main.rs:1492 src/main.rs:1514
+#: src/main.rs:1240 src/main.rs:1278 src/main.rs:1296 src/main.rs:1332 src/main.rs:1511 src/main.rs:1533
 msgid "Ok"
 msgstr ""
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1234
+#: src/main.rs:1253
 msgid "No Boxes"
 msgstr ""
 
 #. TRANSLATORS: Instructions
-#: src/main.rs:1237
+#: src/main.rs:1256
 msgid "Click the + at the top-left to create your first box!"
 msgstr ""
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1249
+#: src/main.rs:1268
 msgid "You appear to be using a Flatpak of BoxBuddy without filesystem access. If you wish to set a Custom Home Directory you will need to grant filesystem access. Please see the <a href='https://dvlv.github.io/BoxBuddyRS/tips'>documentation for details.</a>"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1253
+#: src/main.rs:1272
 msgid "Sandboxed Flatpak Detected"
 msgstr ""
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1268
+#: src/main.rs:1287
 msgid "Distrobox can already access folders in your home directory - even if you have specified a custom home folder"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1272
+#: src/main.rs:1291
 msgid "Volume is already accessible"
 msgstr ""
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1302
+#: src/main.rs:1321
 msgid "You don't appear to have any boxes which can install {} files"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1308
+#: src/main.rs:1327
 msgid "No Suitable Boxes Found"
 msgstr ""
 
 #. TRANSLATORS: Popup Window Title - {} replaced with .deb or .rpm
-#: src/main.rs:1322
+#: src/main.rs:1341
 msgid "Install {} File"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1330
+#: src/main.rs:1349
 msgid "Install"
 msgstr ""
 
 #. TRANSLATORS: Info message - {} replaced with a file path
-#: src/main.rs:1354
+#: src/main.rs:1373
 msgid "Installing: {}"
 msgstr ""
 
-#: src/main.rs:1358
+#: src/main.rs:1377
 msgid "Select a box to install this file into:"
 msgstr ""
 
 #. TRANSLATORS - Label for Dropdown of existing Boxes to install .deb or .rpm into
-#: src/main.rs:1376
+#: src/main.rs:1395
 msgid "Box"
 msgstr ""
 
 #. TRANSLATORS: File type
-#: src/main.rs:1414
+#: src/main.rs:1433
 msgid "DEB Files"
 msgstr ""
 
 #. TRANSLATORS: File type
-#: src/main.rs:1449
+#: src/main.rs:1468
 msgid "RPM Files"
 msgstr ""
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1482
+#: src/main.rs:1501
 msgid "This file is not accessible to Flatpak - please copy it to your Downloads folder, or allow filesystem access. Please see the <a href='https://dvlv.github.io/BoxBuddyRS/tips'>documentation for details.</a>"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1486
+#: src/main.rs:1505
 msgid "File Not Accessible"
 msgstr ""
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1505
+#: src/main.rs:1524
 msgid "This file does not appear to be a {} file"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1509
+#: src/main.rs:1528
 msgid "Incorrect File Type"
 msgstr ""
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:1537
+#: src/main.rs:1556
 msgid "Preferred Terminal"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1545
+#: src/main.rs:1564
 msgid "Save"
 msgstr ""
 
 #. TRANSLATORS: Instructions label
-#: src/main.rs:1566
+#: src/main.rs:1585
 msgid "Select your preferred terminal"
 msgstr ""
 
 #. TRANSLATORS: Label for Dropdown of terminals available
-#: src/main.rs:1586
+#: src/main.rs:1605
 msgid "Terminal"
 msgstr ""
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1606
+#: src/main.rs:1627
 msgid "Terminal Preference Saved!"
 msgstr ""
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1618
+#: src/main.rs:1638
 msgid "Sorry, Preference Could Not Be Saved"
 msgstr ""

--- a/po/de_DE/LC_MESSAGES/de_DE.po
+++ b/po/de_DE/LC_MESSAGES/de_DE.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-13 08:56+0000\n"
+"POT-Creation-Date: 2024-06-14 07:12+0000\n"
 "PO-Revision-Date: 2024-06-13 10:59+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,170 +18,170 @@ msgstr ""
 "X-Generator: Poedit 3.4.4\n"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:139
+#: src/main.rs:150
 msgid "Create A Distrobox"
 msgstr "Distrobox anlegen"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:158
+#: src/main.rs:169
 msgid "Assemble A Distrobox"
 msgstr "Eine Distrobox zusammenbauen"
 
 #. TRANSLATORS: File type
-#: src/main.rs:164
+#: src/main.rs:175
 msgid "INI-Files"
 msgstr "INI-Dateien"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:185
+#: src/main.rs:196
 msgid "Menu"
 msgstr "Menü"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:238
+#: src/main.rs:249
 msgid "Refresh"
 msgstr "Aktualisieren"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:244
+#: src/main.rs:255
 msgid "Set Preferred Terminal"
 msgstr "Bevorzugte Konsole einstellen"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:251
+#: src/main.rs:262
 msgid "About BoxBuddy"
 msgstr "Über BoxBuddy"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:256
+#: src/main.rs:267
 msgid "Quit"
 msgstr "Beenden"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:264
+#: src/main.rs:275
 msgid "Distrobox not found!"
 msgstr "Distrobox konnte nicht gefunden werden!"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:269
+#: src/main.rs:280
 msgid "Distrobox could not be found, please ensure it is installed!"
 msgstr "Distrobox konnte nicht gefunden werden, bitte Installation überprüfen!"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:341
+#: src/main.rs:352
 msgid "Stop Box"
 msgstr "Box anhalten"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:370
+#: src/main.rs:381
 msgid "Open Terminal"
 msgstr "Konsole öffnen"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:383
+#: src/main.rs:394
 msgid "Upgrade Box"
 msgstr "Box aktualisieren"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:395
+#: src/main.rs:406
 msgid "View Applications"
 msgstr "Zeige Anwendungen"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:418
+#: src/main.rs:429
 msgid "Delete Box"
 msgstr "Box löschen"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:431
+#: src/main.rs:442
 msgid "Clone Box"
 msgstr ""
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:451
+#: src/main.rs:462
 msgid "Install .deb File"
 msgstr ".deb Paket installieren"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:463
+#: src/main.rs:474
 msgid "Install .rpm File"
 msgstr ".rpm Paket installieren"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:512 src/main.rs:570
+#: src/main.rs:523 src/main.rs:581
 msgid "Create New Distrobox"
 msgstr "Neue Distrobox anlegen"
 
 #. TRANSLATORS: Context label of the application doing something
-#: src/main.rs:524
+#: src/main.rs:535
 msgid "Assembling Distroboxes, please wait..."
 msgstr "Stelle Distroboxen zusammen, bitte warten..."
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:578
+#: src/main.rs:589
 msgid "Create"
 msgstr "Erstellen"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:583
+#: src/main.rs:594
 msgid "Additional Information"
 msgstr "Weitere Informationen"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:588 src/main.rs:1059 src/main.rs:1104 src/main.rs:1334
-#: src/main.rs:1549
+#: src/main.rs:599 src/main.rs:1078 src/main.rs:1123 src/main.rs:1353
+#: src/main.rs:1568
 msgid "Cancel"
 msgstr "Abbrechen"
 
 #. TRANSLATORS: Entry Label - Name input for new distrobox
-#: src/main.rs:622 src/main.rs:1142
+#: src/main.rs:633 src/main.rs:1161
 msgid "Name"
 msgstr "Name"
 
 #. TRANSLATORS: Entry Label - Select home directory for new distrobox
-#: src/main.rs:643
+#: src/main.rs:654
 msgid "Home Directory (Leave blank for default)"
 msgstr "Nutzerverzeichnis (Leer lassen für Standard)"
 
 #. TRANSLATORS - Label for Dropdown where the user selects the container image to create
-#: src/main.rs:676
+#: src/main.rs:687
 msgid "Image"
 msgstr "Abbild"
 
 #. TRANSLATORS - Label for Toggle when creating box to add systemd support
-#: src/main.rs:683
+#: src/main.rs:694
 msgid "Use init system"
 msgstr "Init System verwenden"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:790
+#: src/main.rs:801
 msgid "Add a volume"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:803
+#: src/main.rs:814
 msgid "Remove volume"
 msgstr ""
 
 #. TRANSLATORS: Help text for volume input
-#: src/main.rs:816
+#: src/main.rs:827
 msgid "Enter the location to mount this folder inside your new box"
 msgstr ""
 "Geben Sie den Pfad an unter welchem dieses Laufwerk in Ihrer neuen Distrobox "
 "verfügbar sein soll"
 
 #. TRANSLATORS: Subheading
-#: src/main.rs:840
+#: src/main.rs:851
 msgid "Additional Volumes:"
 msgstr "Zusätzliche Laufwerke:"
 
 #. TRANSLATORS: Context for the Additional Volumes subheading
-#: src/main.rs:843
+#: src/main.rs:854
 msgid "Additional directories the new box should be able to access"
 msgstr "Zusätzliche Verzeichnisse auf die die neue Box Zugriff haben soll"
 
 #. TRANSLATORS: Description of the application
-#: src/main.rs:867
+#: src/main.rs:878
 msgid ""
 "A Graphical Manager for your Distroboxes.\n"
 "    \n"
@@ -193,113 +193,113 @@ msgid ""
 msgstr ""
 
 #. TRANSLATORS: Window Title - shows list of installed applications in distrobox
-#: src/main.rs:893
+#: src/main.rs:912
 msgid "Installed Applications"
 msgstr "Installierte Anwendungen"
 
 #. TRANSLATORS: Loading Message
-#: src/main.rs:911
+#: src/main.rs:930
 msgid "Loading..."
 msgstr "Lade..."
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:954
+#: src/main.rs:973
 msgid "No Applications Installed"
 msgstr "Keine Anwendungen installiert"
 
 #. TRANSLATORS: Window Title
-#: src/main.rs:959
+#: src/main.rs:978
 msgid "Available Applications"
 msgstr "Verfügbare Anwendungen"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:972
+#: src/main.rs:991
 msgid "Run"
 msgstr "Ausführen"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:988
+#: src/main.rs:1007
 msgid "Remove From Menu"
 msgstr "Aus Menü entfernen"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1005
+#: src/main.rs:1024
 msgid "Add To Menu"
 msgstr "Zu Menü hinzufügen"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1036
+#: src/main.rs:1055
 msgid "App Exported!"
 msgstr "Anwendung exportiert!"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1042
+#: src/main.rs:1061
 msgid "App Removed!"
 msgstr "Anwendung entfernt!"
 
 #. TRANSLATORS: Confirmation Dialogue
-#: src/main.rs:1053
+#: src/main.rs:1072
 msgid "Really Delete?"
 msgstr "Wirklich Löschen?"
 
 #. TRANSLATORS: Confirmation Dialogue - {} replaced with the name of the Distrobox
-#: src/main.rs:1055
+#: src/main.rs:1074
 msgid "Are you sure you want to delete {}?"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1061
+#: src/main.rs:1080
 msgid "Delete"
 msgstr "Löschen"
 
 #. TRANSLATORS: Success Text
-#: src/main.rs:1074
+#: src/main.rs:1093
 msgid "Box Deleted!"
 msgstr "Box gelöscht!"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1096 src/main.rs:1100
+#: src/main.rs:1115 src/main.rs:1119
 msgid "Clone"
 msgstr ""
 
 #. TRANSLATORS: Title / Instruction label
-#: src/main.rs:1126
+#: src/main.rs:1145
 msgid "Enter the name of your new box"
 msgstr ""
 
-#: src/main.rs:1130
+#: src/main.rs:1149
 msgid "Note: Cloning can take a long time, please be patient"
 msgstr ""
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1211
+#: src/main.rs:1230
 msgid "Please install one of the supported terminals:"
 msgstr "Bitte installieren Sie einen der unterstützen Terminal Emulatoren:"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1216
+#: src/main.rs:1235
 msgid "No supported terminal found"
 msgstr "Keinen unterstützen Terminal Emulator gefunden"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1221 src/main.rs:1259 src/main.rs:1277 src/main.rs:1313
-#: src/main.rs:1492 src/main.rs:1514
+#: src/main.rs:1240 src/main.rs:1278 src/main.rs:1296 src/main.rs:1332
+#: src/main.rs:1511 src/main.rs:1533
 msgid "Ok"
 msgstr "Okay"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1234
+#: src/main.rs:1253
 msgid "No Boxes"
 msgstr "Keine Boxen"
 
 #. TRANSLATORS: Instructions
-#: src/main.rs:1237
+#: src/main.rs:1256
 msgid "Click the + at the top-left to create your first box!"
 msgstr ""
 "Klicken Sie auf + in der oberen linken Ecke um die erste Box zu erstellen!"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1249
+#: src/main.rs:1268
 msgid ""
 "You appear to be using a Flatpak of BoxBuddy without filesystem access. If "
 "you wish to set a Custom Home Directory you will need to grant filesystem "
@@ -313,12 +313,12 @@ msgstr ""
 "a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1253
+#: src/main.rs:1272
 msgid "Sandboxed Flatpak Detected"
 msgstr "Flatpak Sandbox erkannt"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1268
+#: src/main.rs:1287
 msgid ""
 "Distrobox can already access folders in your home directory - even if you "
 "have specified a custom home folder"
@@ -327,56 +327,56 @@ msgstr ""
 "benutzerdefiniertes Nutzerverzeichnis angegeben haben"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1272
+#: src/main.rs:1291
 msgid "Volume is already accessible"
 msgstr "Laufwerkszugriff bereits gewährt"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1302
+#: src/main.rs:1321
 msgid "You don't appear to have any boxes which can install {} files"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1308
+#: src/main.rs:1327
 msgid "No Suitable Boxes Found"
 msgstr "Keine passenden Boxen gefunden"
 
 #. TRANSLATORS: Popup Window Title - {} replaced with .deb or .rpm
-#: src/main.rs:1322
+#: src/main.rs:1341
 msgid "Install {} File"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1330
+#: src/main.rs:1349
 msgid "Install"
 msgstr "Installieren"
 
 #. TRANSLATORS: Info message - {} replaced with a file path
-#: src/main.rs:1354
+#: src/main.rs:1373
 msgid "Installing: {}"
 msgstr ""
 
-#: src/main.rs:1358
+#: src/main.rs:1377
 msgid "Select a box to install this file into:"
 msgstr "Wählen Sie eine Box, in der diese Datei installiert werden soll:"
 
 #. TRANSLATORS - Label for Dropdown of existing Boxes to install .deb or .rpm into
-#: src/main.rs:1376
+#: src/main.rs:1395
 msgid "Box"
 msgstr "Box"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1414
+#: src/main.rs:1433
 msgid "DEB Files"
 msgstr "DEB Dateien"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1449
+#: src/main.rs:1468
 msgid "RPM Files"
 msgstr "RPM Dateien"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1482
+#: src/main.rs:1501
 msgid ""
 "This file is not accessible to Flatpak - please copy it to your Downloads "
 "folder, or allow filesystem access. Please see the <a href='https://dvlv."
@@ -388,47 +388,47 @@ msgstr ""
 "tips'>Dokumentation.</a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1486
+#: src/main.rs:1505
 msgid "File Not Accessible"
 msgstr "Kein Zugriff"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1505
+#: src/main.rs:1524
 msgid "This file does not appear to be a {} file"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1509
+#: src/main.rs:1528
 msgid "Incorrect File Type"
 msgstr "Dateityp ist nicht korrekt"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:1537
+#: src/main.rs:1556
 msgid "Preferred Terminal"
 msgstr "Bevorzugte Konsole"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1545
+#: src/main.rs:1564
 msgid "Save"
 msgstr "Speichern"
 
 #. TRANSLATORS: Instructions label
-#: src/main.rs:1566
+#: src/main.rs:1585
 msgid "Select your preferred terminal"
 msgstr "Wählen Sie Ihre bevorzugte Konsole"
 
 #. TRANSLATORS: Label for Dropdown of terminals available
-#: src/main.rs:1586
+#: src/main.rs:1605
 msgid "Terminal"
 msgstr "Konsole"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1606
+#: src/main.rs:1627
 msgid "Terminal Preference Saved!"
 msgstr "Präferenz gespeichert!"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1618
+#: src/main.rs:1638
 msgid "Sorry, Preference Could Not Be Saved"
 msgstr "Das tut uns leid, Präferenz konnte nicht gespeichert werden"
 

--- a/po/el/LC_MESSAGES/el.po
+++ b/po/el/LC_MESSAGES/el.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: BoxBuddy Greek Translation\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-13 08:56+0000\n"
+"POT-Creation-Date: 2024-06-14 07:12+0000\n"
 "PO-Revision-Date: 2024-06-13 10:57+0200\n"
 "Last-Translator: Karachalios Stagkas Athanasios Nektarios <nasos.karachalios."
 "stagkas@proton.me>\n"
@@ -25,170 +25,170 @@ msgstr ""
 "X-DL-Domain: \n"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:139
+#: src/main.rs:150
 msgid "Create A Distrobox"
 msgstr "Δημιουργήστε ένα Distrobox"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:158
+#: src/main.rs:169
 msgid "Assemble A Distrobox"
 msgstr "Συντάξτε ένα Distrobox"
 
 #. TRANSLATORS: File type
-#: src/main.rs:164
+#: src/main.rs:175
 msgid "INI-Files"
 msgstr "Αρχεία INI"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:185
+#: src/main.rs:196
 msgid "Menu"
 msgstr "Μενού"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:238
+#: src/main.rs:249
 msgid "Refresh"
 msgstr "Ανανέωση"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:244
+#: src/main.rs:255
 msgid "Set Preferred Terminal"
 msgstr "Ορισμός προτιμώμενου τερματικού"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:251
+#: src/main.rs:262
 msgid "About BoxBuddy"
 msgstr "Περί BoxBuddy"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:256
+#: src/main.rs:267
 msgid "Quit"
 msgstr "Έξοδος"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:264
+#: src/main.rs:275
 msgid "Distrobox not found!"
 msgstr "Το Distrobox δεν βρέθηκε!"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:269
+#: src/main.rs:280
 msgid "Distrobox could not be found, please ensure it is installed!"
 msgstr "Το Distrobox δεν βρέθηκε, βεβαιωθείτε ότι είναι εγκατεστημένο!"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:341
+#: src/main.rs:352
 msgid "Stop Box"
 msgstr "Διακοπή κουτιού"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:370
+#: src/main.rs:381
 msgid "Open Terminal"
 msgstr "Άνοιγμα τερματικού"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:383
+#: src/main.rs:394
 msgid "Upgrade Box"
 msgstr "Αναβάθμιση κουτιού"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:395
+#: src/main.rs:406
 msgid "View Applications"
 msgstr "Προβολή εφαρμογών"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:418
+#: src/main.rs:429
 msgid "Delete Box"
 msgstr "Διαγραφή κουτιού"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:431
+#: src/main.rs:442
 msgid "Clone Box"
 msgstr "Κλωνοποίηση κουτιού"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:451
+#: src/main.rs:462
 msgid "Install .deb File"
 msgstr "Εγκατάσταση αρχείου .deb"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:463
+#: src/main.rs:474
 msgid "Install .rpm File"
 msgstr "Εγκατάσταση αρχείου .rpm"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:512 src/main.rs:570
+#: src/main.rs:523 src/main.rs:581
 msgid "Create New Distrobox"
 msgstr "Δημιουργία νέου Distrobox"
 
 #. TRANSLATORS: Context label of the application doing something
-#: src/main.rs:524
+#: src/main.rs:535
 msgid "Assembling Distroboxes, please wait..."
 msgstr "Συντάξει Distroboxes, παρακαλώ περιμένετε..."
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:578
+#: src/main.rs:589
 msgid "Create"
 msgstr "Δημιουργία"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:583
+#: src/main.rs:594
 msgid "Additional Information"
 msgstr "Επιπλέον πληροφορίες"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:588 src/main.rs:1059 src/main.rs:1104 src/main.rs:1334
-#: src/main.rs:1549
+#: src/main.rs:599 src/main.rs:1078 src/main.rs:1123 src/main.rs:1353
+#: src/main.rs:1568
 msgid "Cancel"
 msgstr "Ακύρωση"
 
 #. TRANSLATORS: Entry Label - Name input for new distrobox
-#: src/main.rs:622 src/main.rs:1142
+#: src/main.rs:633 src/main.rs:1161
 msgid "Name"
 msgstr "Όνομα"
 
 #. TRANSLATORS: Entry Label - Select home directory for new distrobox
-#: src/main.rs:643
+#: src/main.rs:654
 msgid "Home Directory (Leave blank for default)"
 msgstr "Πρωσοπικός Φάκελος.(Αφήστε το κενό για προεπιλογή)"
 
 #. TRANSLATORS - Label for Dropdown where the user selects the container image to create
-#: src/main.rs:676
+#: src/main.rs:687
 msgid "Image"
 msgstr "Ειδώλιο"
 
 #. TRANSLATORS - Label for Toggle when creating box to add systemd support
-#: src/main.rs:683
+#: src/main.rs:694
 msgid "Use init system"
 msgstr "Χρησιμοποιήστε το σύστημα init"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:790
+#: src/main.rs:801
 msgid "Add a volume"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:803
+#: src/main.rs:814
 msgid "Remove volume"
 msgstr ""
 
 #. TRANSLATORS: Help text for volume input
-#: src/main.rs:816
+#: src/main.rs:827
 msgid "Enter the location to mount this folder inside your new box"
 msgstr ""
 "Εισάγετε τη θέση για την προσάρτηση αυτού του φακέλου μέσα στο νέο σας κουτί"
 
 #. TRANSLATORS: Subheading
-#: src/main.rs:840
+#: src/main.rs:851
 msgid "Additional Volumes:"
 msgstr "Πρόσθετοι τόμοι:"
 
 #. TRANSLATORS: Context for the Additional Volumes subheading
-#: src/main.rs:843
+#: src/main.rs:854
 msgid "Additional directories the new box should be able to access"
 msgstr ""
 "Πρόσθετοι κατάλογοι στους οποίους θα πρέπει να έχει πρόσβαση το νέο κουτί"
 
 #. TRANSLATORS: Description of the application
-#: src/main.rs:867
+#: src/main.rs:878
 msgid ""
 "A Graphical Manager for your Distroboxes.\n"
 "    \n"
@@ -200,115 +200,115 @@ msgid ""
 msgstr ""
 
 #. TRANSLATORS: Window Title - shows list of installed applications in distrobox
-#: src/main.rs:893
+#: src/main.rs:912
 msgid "Installed Applications"
 msgstr "Εγκατεστημένες εφαρμογές"
 
 #. TRANSLATORS: Loading Message
-#: src/main.rs:911
+#: src/main.rs:930
 msgid "Loading..."
 msgstr "Φόρτωση..."
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:954
+#: src/main.rs:973
 msgid "No Applications Installed"
 msgstr "Δεν υπάρχουν εγκατεστημένες εφαρμογές"
 
 #. TRANSLATORS: Window Title
-#: src/main.rs:959
+#: src/main.rs:978
 msgid "Available Applications"
 msgstr "Διαθέσιμες εφαρμογές"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:972
+#: src/main.rs:991
 msgid "Run"
 msgstr "Εκτέλεση"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:988
+#: src/main.rs:1007
 msgid "Remove From Menu"
 msgstr "Αφαίρεση από το μενού"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1005
+#: src/main.rs:1024
 msgid "Add To Menu"
 msgstr "Προσθήκη στο μενού"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1036
+#: src/main.rs:1055
 msgid "App Exported!"
 msgstr "Η εφαρμογή εξήχθη!"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1042
+#: src/main.rs:1061
 msgid "App Removed!"
 msgstr "Η εφαρμογή αφαιρέθηκε!"
 
 #. TRANSLATORS: Confirmation Dialogue
-#: src/main.rs:1053
+#: src/main.rs:1072
 msgid "Really Delete?"
 msgstr "Θέλετε να διαγράψετε;"
 
 #. TRANSLATORS: Confirmation Dialogue - {} replaced with the name of the Distrobox
-#: src/main.rs:1055
+#: src/main.rs:1074
 msgid "Are you sure you want to delete {}?"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1061
+#: src/main.rs:1080
 msgid "Delete"
 msgstr "Διαγραφή"
 
 #. TRANSLATORS: Success Text
-#: src/main.rs:1074
+#: src/main.rs:1093
 msgid "Box Deleted!"
 msgstr "Το κουτί διαγράφηκε!"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1096 src/main.rs:1100
+#: src/main.rs:1115 src/main.rs:1119
 msgid "Clone"
 msgstr "Κλωνοποίηση"
 
 #. TRANSLATORS: Title / Instruction label
-#: src/main.rs:1126
+#: src/main.rs:1145
 msgid "Enter the name of your new box"
 msgstr "Εισάγετε το όνομα του νέου σας κουτιού"
 
-#: src/main.rs:1130
+#: src/main.rs:1149
 msgid "Note: Cloning can take a long time, please be patient"
 msgstr ""
 "Σημείωση: Η κλωνοποίηση μπορεί να διαρκέσει αρκετό χρόνο, παρακαλούμε να "
 "είστε υπομονετικοί."
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1211
+#: src/main.rs:1230
 msgid "Please install one of the supported terminals:"
 msgstr "Παρακαλώ εγκαταστήστε ένα από τα υποστηριζόμενα τερματικά:"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1216
+#: src/main.rs:1235
 msgid "No supported terminal found"
 msgstr "Δεν βρέθηκε υποστηριζόμενο τερματικό"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1221 src/main.rs:1259 src/main.rs:1277 src/main.rs:1313
-#: src/main.rs:1492 src/main.rs:1514
+#: src/main.rs:1240 src/main.rs:1278 src/main.rs:1296 src/main.rs:1332
+#: src/main.rs:1511 src/main.rs:1533
 msgid "Ok"
 msgstr "Εντάξει"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1234
+#: src/main.rs:1253
 msgid "No Boxes"
 msgstr "Δεν υπάρχουν κουτιά"
 
 #. TRANSLATORS: Instructions
-#: src/main.rs:1237
+#: src/main.rs:1256
 msgid "Click the + at the top-left to create your first box!"
 msgstr ""
 "Κάντε κλικ στο + πάνω αριστερά για να δημιουργήσετε το πρώτο σας κουτί!"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1249
+#: src/main.rs:1268
 msgid ""
 "You appear to be using a Flatpak of BoxBuddy without filesystem access. If "
 "you wish to set a Custom Home Directory you will need to grant filesystem "
@@ -322,12 +322,12 @@ msgstr ""
 "details.</a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1253
+#: src/main.rs:1272
 msgid "Sandboxed Flatpak Detected"
 msgstr "Εντοπίστηκε Sandboxed Flatpak"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1268
+#: src/main.rs:1287
 msgid ""
 "Distrobox can already access folders in your home directory - even if you "
 "have specified a custom home folder"
@@ -336,56 +336,56 @@ msgstr ""
 "κατάλογο - ακόμα και αν έχετε ορίσει έναν προσαρμοσμένο προσωπικό φάκελο"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1272
+#: src/main.rs:1291
 msgid "Volume is already accessible"
 msgstr "Ο τόμος είναι ήδη προσβάσιμος"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1302
+#: src/main.rs:1321
 msgid "You don't appear to have any boxes which can install {} files"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1308
+#: src/main.rs:1327
 msgid "No Suitable Boxes Found"
 msgstr "Δεν βρέθηκαν κατάλληλα κουτιά"
 
 #. TRANSLATORS: Popup Window Title - {} replaced with .deb or .rpm
-#: src/main.rs:1322
+#: src/main.rs:1341
 msgid "Install {} File"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1330
+#: src/main.rs:1349
 msgid "Install"
 msgstr "Εγκατάσταση"
 
 #. TRANSLATORS: Info message - {} replaced with a file path
-#: src/main.rs:1354
+#: src/main.rs:1373
 msgid "Installing: {}"
 msgstr ""
 
-#: src/main.rs:1358
+#: src/main.rs:1377
 msgid "Select a box to install this file into:"
 msgstr "Επιλέξτε ένα πλαίσιο για να εγκαταστήσετε αυτό το αρχείο:"
 
 #. TRANSLATORS - Label for Dropdown of existing Boxes to install .deb or .rpm into
-#: src/main.rs:1376
+#: src/main.rs:1395
 msgid "Box"
 msgstr "Κουτί"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1414
+#: src/main.rs:1433
 msgid "DEB Files"
 msgstr "Αρχεία DEB"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1449
+#: src/main.rs:1468
 msgid "RPM Files"
 msgstr "Αρχεία RPM"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1482
+#: src/main.rs:1501
 msgid ""
 "This file is not accessible to Flatpak - please copy it to your Downloads "
 "folder, or allow filesystem access. Please see the <a href='https://dvlv."
@@ -397,46 +397,46 @@ msgstr ""
 "λεπτομέρειες.</a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1486
+#: src/main.rs:1505
 msgid "File Not Accessible"
 msgstr "Το αρχείο δεν είναι προσβάσιμο"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1505
+#: src/main.rs:1524
 msgid "This file does not appear to be a {} file"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1509
+#: src/main.rs:1528
 msgid "Incorrect File Type"
 msgstr "Λανθασμένος τύπος αρχείου"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:1537
+#: src/main.rs:1556
 msgid "Preferred Terminal"
 msgstr "Προτιμώμενος Τερματικός "
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1545
+#: src/main.rs:1564
 msgid "Save"
 msgstr "Αποθήκευση"
 
 #. TRANSLATORS: Instructions label
-#: src/main.rs:1566
+#: src/main.rs:1585
 msgid "Select your preferred terminal"
 msgstr "Επιλέξτε τον τερματικό που προτιμάτε"
 
 #. TRANSLATORS: Label for Dropdown of terminals available
-#: src/main.rs:1586
+#: src/main.rs:1605
 msgid "Terminal"
 msgstr "Τερματικός"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1606
+#: src/main.rs:1627
 msgid "Terminal Preference Saved!"
 msgstr "Προτίμηση τερματικού αποθηκεύτηκε!"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1618
+#: src/main.rs:1638
 msgid "Sorry, Preference Could Not Be Saved"
 msgstr "Λυπάμαι, η προτίμηση δεν μπόρεσε να αποθηκευτεί"

--- a/po/es/LC_MESSAGES/es.po
+++ b/po/es/LC_MESSAGES/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-13 08:56+0000\n"
+"POT-Creation-Date: 2024-06-14 07:12+0000\n"
 "PO-Revision-Date: 2024-06-13 10:57+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,170 +19,170 @@ msgstr ""
 "X-Generator: Poedit 3.4.4\n"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:139
+#: src/main.rs:150
 msgid "Create A Distrobox"
 msgstr "Crear una Distrobox"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:158
+#: src/main.rs:169
 msgid "Assemble A Distrobox"
 msgstr "Armar una Distrobox"
 
 #. TRANSLATORS: File type
-#: src/main.rs:164
+#: src/main.rs:175
 msgid "INI-Files"
 msgstr "Archivos INI"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:185
+#: src/main.rs:196
 msgid "Menu"
 msgstr "Menú"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:238
+#: src/main.rs:249
 msgid "Refresh"
 msgstr "Refrescar"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:244
+#: src/main.rs:255
 msgid "Set Preferred Terminal"
 msgstr "Establecer Terminal Preferida"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:251
+#: src/main.rs:262
 msgid "About BoxBuddy"
 msgstr "Acerca de BoxBuddy"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:256
+#: src/main.rs:267
 msgid "Quit"
 msgstr "Salir"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:264
+#: src/main.rs:275
 msgid "Distrobox not found!"
 msgstr "Distrobox no encontrado!"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:269
+#: src/main.rs:280
 msgid "Distrobox could not be found, please ensure it is installed!"
 msgstr "No se pudo encontrar Distrobox, ¡asegúrese de que esté instalado!"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:341
+#: src/main.rs:352
 msgid "Stop Box"
 msgstr "Detener Box"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:370
+#: src/main.rs:381
 msgid "Open Terminal"
 msgstr "Abrir Terminal"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:383
+#: src/main.rs:394
 msgid "Upgrade Box"
 msgstr "Actualizar Box"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:395
+#: src/main.rs:406
 msgid "View Applications"
 msgstr "Ver aplicaciones"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:418
+#: src/main.rs:429
 msgid "Delete Box"
 msgstr "Eliminar Box"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:431
+#: src/main.rs:442
 msgid "Clone Box"
 msgstr "Clonar Box"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:451
+#: src/main.rs:462
 msgid "Install .deb File"
 msgstr "Instalar Archivo .deb"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:463
+#: src/main.rs:474
 msgid "Install .rpm File"
 msgstr "Instalar Archivo .rpm"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:512 src/main.rs:570
+#: src/main.rs:523 src/main.rs:581
 msgid "Create New Distrobox"
 msgstr "Crear Nueva Distrobox"
 
 #. TRANSLATORS: Context label of the application doing something
-#: src/main.rs:524
+#: src/main.rs:535
 msgid "Assembling Distroboxes, please wait..."
 msgstr "Armando Distroboxes, por favor espere..."
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:578
+#: src/main.rs:589
 msgid "Create"
 msgstr "Crear"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:583
+#: src/main.rs:594
 msgid "Additional Information"
 msgstr "Información Adicional"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:588 src/main.rs:1059 src/main.rs:1104 src/main.rs:1334
-#: src/main.rs:1549
+#: src/main.rs:599 src/main.rs:1078 src/main.rs:1123 src/main.rs:1353
+#: src/main.rs:1568
 msgid "Cancel"
 msgstr "Cancelar"
 
 #. TRANSLATORS: Entry Label - Name input for new distrobox
-#: src/main.rs:622 src/main.rs:1142
+#: src/main.rs:633 src/main.rs:1161
 msgid "Name"
 msgstr "Nombre"
 
 #. TRANSLATORS: Entry Label - Select home directory for new distrobox
-#: src/main.rs:643
+#: src/main.rs:654
 msgid "Home Directory (Leave blank for default)"
 msgstr ""
 "Directorio de Home (dejar en blanco para seleccionar directorio \"Home\" por "
 "defecto)"
 
 #. TRANSLATORS - Label for Dropdown where the user selects the container image to create
-#: src/main.rs:676
+#: src/main.rs:687
 msgid "Image"
 msgstr "Imagen"
 
 #. TRANSLATORS - Label for Toggle when creating box to add systemd support
-#: src/main.rs:683
+#: src/main.rs:694
 msgid "Use init system"
 msgstr "Utilizar sistema init"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:790
+#: src/main.rs:801
 msgid "Add a volume"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:803
+#: src/main.rs:814
 msgid "Remove volume"
 msgstr ""
 
 #. TRANSLATORS: Help text for volume input
-#: src/main.rs:816
+#: src/main.rs:827
 msgid "Enter the location to mount this folder inside your new box"
 msgstr "Ingrese el directorio para montar esta carpeta dentro de su nueva caja"
 
 #. TRANSLATORS: Subheading
-#: src/main.rs:840
+#: src/main.rs:851
 msgid "Additional Volumes:"
 msgstr "Volúmenes adicionales:"
 
 #. TRANSLATORS: Context for the Additional Volumes subheading
-#: src/main.rs:843
+#: src/main.rs:854
 msgid "Additional directories the new box should be able to access"
 msgstr "Directorios adicionales a los que la nueva Box debería poder acceder"
 
 #. TRANSLATORS: Description of the application
-#: src/main.rs:867
+#: src/main.rs:878
 msgid ""
 "A Graphical Manager for your Distroboxes.\n"
 "    \n"
@@ -194,113 +194,113 @@ msgid ""
 msgstr ""
 
 #. TRANSLATORS: Window Title - shows list of installed applications in distrobox
-#: src/main.rs:893
+#: src/main.rs:912
 msgid "Installed Applications"
 msgstr "Aplicaciones Instaladas"
 
 #. TRANSLATORS: Loading Message
-#: src/main.rs:911
+#: src/main.rs:930
 msgid "Loading..."
 msgstr "Cargando..."
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:954
+#: src/main.rs:973
 msgid "No Applications Installed"
 msgstr "Sin Aplicaciones Instaladas"
 
 #. TRANSLATORS: Window Title
-#: src/main.rs:959
+#: src/main.rs:978
 msgid "Available Applications"
 msgstr "Aplicaciones Disponibles"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:972
+#: src/main.rs:991
 msgid "Run"
 msgstr "Ejecutar"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:988
+#: src/main.rs:1007
 msgid "Remove From Menu"
 msgstr "Quitar del menú"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1005
+#: src/main.rs:1024
 msgid "Add To Menu"
 msgstr "Añadir al Menu"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1036
+#: src/main.rs:1055
 msgid "App Exported!"
 msgstr "App Exportada!"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1042
+#: src/main.rs:1061
 msgid "App Removed!"
 msgstr "App Eliminada!"
 
 #. TRANSLATORS: Confirmation Dialogue
-#: src/main.rs:1053
+#: src/main.rs:1072
 msgid "Really Delete?"
 msgstr "¿Eliminar?"
 
 #. TRANSLATORS: Confirmation Dialogue - {} replaced with the name of the Distrobox
-#: src/main.rs:1055
+#: src/main.rs:1074
 msgid "Are you sure you want to delete {}?"
 msgstr "¿Estás seguro(a) de que quieres eliminar {}?"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1061
+#: src/main.rs:1080
 msgid "Delete"
 msgstr "Eliminar"
 
 #. TRANSLATORS: Success Text
-#: src/main.rs:1074
+#: src/main.rs:1093
 msgid "Box Deleted!"
 msgstr "Box Eliminada!"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1096 src/main.rs:1100
+#: src/main.rs:1115 src/main.rs:1119
 msgid "Clone"
 msgstr ""
 
 #. TRANSLATORS: Title / Instruction label
-#: src/main.rs:1126
+#: src/main.rs:1145
 msgid "Enter the name of your new box"
 msgstr ""
 
-#: src/main.rs:1130
+#: src/main.rs:1149
 msgid "Note: Cloning can take a long time, please be patient"
 msgstr ""
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1211
+#: src/main.rs:1230
 msgid "Please install one of the supported terminals:"
 msgstr "Instale uno de los terminales compatibles:"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1216
+#: src/main.rs:1235
 msgid "No supported terminal found"
 msgstr "No se encontró ningún terminal compatible"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1221 src/main.rs:1259 src/main.rs:1277 src/main.rs:1313
-#: src/main.rs:1492 src/main.rs:1514
+#: src/main.rs:1240 src/main.rs:1278 src/main.rs:1296 src/main.rs:1332
+#: src/main.rs:1511 src/main.rs:1533
 msgid "Ok"
 msgstr "Ok"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1234
+#: src/main.rs:1253
 msgid "No Boxes"
 msgstr "Sin Boxes"
 
 #. TRANSLATORS: Instructions
-#: src/main.rs:1237
+#: src/main.rs:1256
 msgid "Click the + at the top-left to create your first box!"
 msgstr ""
 "¡Haz clic en + en la parte superior izquierda para crear tu primera Box!"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1249
+#: src/main.rs:1268
 msgid ""
 "You appear to be using a Flatpak of BoxBuddy without filesystem access. If "
 "you wish to set a Custom Home Directory you will need to grant filesystem "
@@ -314,12 +314,12 @@ msgstr ""
 "detalles.</a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1253
+#: src/main.rs:1272
 msgid "Sandboxed Flatpak Detected"
 msgstr "Flatpak con Sandboxing Detectado!"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1268
+#: src/main.rs:1287
 msgid ""
 "Distrobox can already access folders in your home directory - even if you "
 "have specified a custom home folder"
@@ -328,56 +328,56 @@ msgstr ""
 "ha especificado una carpeta home personalizada"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1272
+#: src/main.rs:1291
 msgid "Volume is already accessible"
 msgstr "El volumen ya es accesible"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1302
+#: src/main.rs:1321
 msgid "You don't appear to have any boxes which can install {} files"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1308
+#: src/main.rs:1327
 msgid "No Suitable Boxes Found"
 msgstr "No se encontraron Box adecuadas"
 
 #. TRANSLATORS: Popup Window Title - {} replaced with .deb or .rpm
-#: src/main.rs:1322
+#: src/main.rs:1341
 msgid "Install {} File"
 msgstr "Instalar Archivo {}"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1330
+#: src/main.rs:1349
 msgid "Install"
 msgstr "Instalar"
 
 #. TRANSLATORS: Info message - {} replaced with a file path
-#: src/main.rs:1354
+#: src/main.rs:1373
 msgid "Installing: {}"
 msgstr ""
 
-#: src/main.rs:1358
+#: src/main.rs:1377
 msgid "Select a box to install this file into:"
 msgstr "Seleccione una Box en la cual instalar este archivo:"
 
 #. TRANSLATORS - Label for Dropdown of existing Boxes to install .deb or .rpm into
-#: src/main.rs:1376
+#: src/main.rs:1395
 msgid "Box"
 msgstr "Box"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1414
+#: src/main.rs:1433
 msgid "DEB Files"
 msgstr "Archivos DEB"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1449
+#: src/main.rs:1468
 msgid "RPM Files"
 msgstr "Archivos RPM"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1482
+#: src/main.rs:1501
 msgid ""
 "This file is not accessible to Flatpak - please copy it to your Downloads "
 "folder, or allow filesystem access. Please see the <a href='https://dvlv."
@@ -388,46 +388,46 @@ msgstr ""
 "dvlv.github.io/BoxBuddyRS/tips'>documentación para obtener más detalles.</a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1486
+#: src/main.rs:1505
 msgid "File Not Accessible"
 msgstr "Archivo no accesible"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1505
+#: src/main.rs:1524
 msgid "This file does not appear to be a {} file"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1509
+#: src/main.rs:1528
 msgid "Incorrect File Type"
 msgstr "Tipo de archivo incorrecto"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:1537
+#: src/main.rs:1556
 msgid "Preferred Terminal"
 msgstr "Terminal Preferida"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1545
+#: src/main.rs:1564
 msgid "Save"
 msgstr "Guardar"
 
 #. TRANSLATORS: Instructions label
-#: src/main.rs:1566
+#: src/main.rs:1585
 msgid "Select your preferred terminal"
 msgstr "Seleccione su terminal preferida"
 
 #. TRANSLATORS: Label for Dropdown of terminals available
-#: src/main.rs:1586
+#: src/main.rs:1605
 msgid "Terminal"
 msgstr "Terminal"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1606
+#: src/main.rs:1627
 msgid "Terminal Preference Saved!"
 msgstr "Preferencia de Terminal Guardada!"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1618
+#: src/main.rs:1638
 msgid "Sorry, Preference Could Not Be Saved"
 msgstr "Lo sentimos, no se pudo guardar la preferencia"

--- a/po/fr_FR/LC_MESSAGES/fr_FR.po
+++ b/po/fr_FR/LC_MESSAGES/fr_FR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-13 08:56+0000\n"
+"POT-Creation-Date: 2024-06-14 07:12+0000\n"
 "PO-Revision-Date: 2024-06-13 10:58+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,169 +19,169 @@ msgstr ""
 "X-Generator: Poedit 3.4.4\n"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:139
+#: src/main.rs:150
 msgid "Create A Distrobox"
 msgstr "Créer une Distrobox"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:158
+#: src/main.rs:169
 msgid "Assemble A Distrobox"
 msgstr "Assembler une Distrobox"
 
 #. TRANSLATORS: File type
-#: src/main.rs:164
+#: src/main.rs:175
 msgid "INI-Files"
 msgstr "Fichiers INI"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:185
+#: src/main.rs:196
 msgid "Menu"
 msgstr "Menu"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:238
+#: src/main.rs:249
 msgid "Refresh"
 msgstr "Actualiser"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:244
+#: src/main.rs:255
 msgid "Set Preferred Terminal"
 msgstr "Choix du terminal préféré"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:251
+#: src/main.rs:262
 msgid "About BoxBuddy"
 msgstr "À propos de BoxBuddy"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:256
+#: src/main.rs:267
 msgid "Quit"
 msgstr "Quitter"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:264
+#: src/main.rs:275
 msgid "Distrobox not found!"
 msgstr "Distrobox introuvable !"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:269
+#: src/main.rs:280
 msgid "Distrobox could not be found, please ensure it is installed!"
 msgstr "Distrobox est introuvable, veuillez vérifier qu’il soit installé !"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:341
+#: src/main.rs:352
 msgid "Stop Box"
 msgstr "Arrêter la Box"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:370
+#: src/main.rs:381
 msgid "Open Terminal"
 msgstr "Ouvrir un terminal"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:383
+#: src/main.rs:394
 msgid "Upgrade Box"
 msgstr "Mettre à jour la Box"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:395
+#: src/main.rs:406
 msgid "View Applications"
 msgstr "Voir les applications"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:418
+#: src/main.rs:429
 msgid "Delete Box"
 msgstr "Supprimer la Box"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:431
+#: src/main.rs:442
 msgid "Clone Box"
 msgstr "Cloner la Box"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:451
+#: src/main.rs:462
 msgid "Install .deb File"
 msgstr "Installer un fichier .deb"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:463
+#: src/main.rs:474
 msgid "Install .rpm File"
 msgstr "Installer un fichier .rpm"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:512 src/main.rs:570
+#: src/main.rs:523 src/main.rs:581
 msgid "Create New Distrobox"
 msgstr "Créer une nouvelle Distrobox"
 
 #. TRANSLATORS: Context label of the application doing something
-#: src/main.rs:524
+#: src/main.rs:535
 msgid "Assembling Distroboxes, please wait..."
 msgstr "Assemblage des Distroboxs, veuillez patienter…"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:578
+#: src/main.rs:589
 msgid "Create"
 msgstr "Créer"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:583
+#: src/main.rs:594
 msgid "Additional Information"
 msgstr "Plus d’informations"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:588 src/main.rs:1059 src/main.rs:1104 src/main.rs:1334
-#: src/main.rs:1549
+#: src/main.rs:599 src/main.rs:1078 src/main.rs:1123 src/main.rs:1353
+#: src/main.rs:1568
 msgid "Cancel"
 msgstr "Annuler"
 
 #. TRANSLATORS: Entry Label - Name input for new distrobox
-#: src/main.rs:622 src/main.rs:1142
+#: src/main.rs:633 src/main.rs:1161
 msgid "Name"
 msgstr "Nom"
 
 #. TRANSLATORS: Entry Label - Select home directory for new distrobox
-#: src/main.rs:643
+#: src/main.rs:654
 msgid "Home Directory (Leave blank for default)"
 msgstr "Répertoire personnel (laisser vide pour le répertoire par défaut)"
 
 #. TRANSLATORS - Label for Dropdown where the user selects the container image to create
-#: src/main.rs:676
+#: src/main.rs:687
 msgid "Image"
 msgstr "Image"
 
 #. TRANSLATORS - Label for Toggle when creating box to add systemd support
-#: src/main.rs:683
+#: src/main.rs:694
 msgid "Use init system"
 msgstr "Utiliser un système d’init"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:790
+#: src/main.rs:801
 msgid "Add a volume"
 msgstr "Ajouter un volume"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:803
+#: src/main.rs:814
 msgid "Remove volume"
 msgstr "Supprimer le volume"
 
 #. TRANSLATORS: Help text for volume input
-#: src/main.rs:816
+#: src/main.rs:827
 msgid "Enter the location to mount this folder inside your new box"
 msgstr "Entrez l’emplacement où monter ce dossier dans la nouvelle Box"
 
 #. TRANSLATORS: Subheading
-#: src/main.rs:840
+#: src/main.rs:851
 msgid "Additional Volumes:"
 msgstr "Volumes supplémentaires :"
 
 #. TRANSLATORS: Context for the Additional Volumes subheading
-#: src/main.rs:843
+#: src/main.rs:854
 msgid "Additional directories the new box should be able to access"
 msgstr ""
 "Répertoires supplémentaires auxquels la nouvelle Box devrait pouvoir accéder"
 
 #. TRANSLATORS: Description of the application
-#: src/main.rs:867
+#: src/main.rs:878
 msgid ""
 "A Graphical Manager for your Distroboxes.\n"
 "    \n"
@@ -200,112 +200,112 @@ msgstr ""
 "propriétaires respectifs."
 
 #. TRANSLATORS: Window Title - shows list of installed applications in distrobox
-#: src/main.rs:893
+#: src/main.rs:912
 msgid "Installed Applications"
 msgstr "Applications installées"
 
 #. TRANSLATORS: Loading Message
-#: src/main.rs:911
+#: src/main.rs:930
 msgid "Loading..."
 msgstr "Chargement…"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:954
+#: src/main.rs:973
 msgid "No Applications Installed"
 msgstr "Pas d’applications installées"
 
 #. TRANSLATORS: Window Title
-#: src/main.rs:959
+#: src/main.rs:978
 msgid "Available Applications"
 msgstr "Applications disponibles"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:972
+#: src/main.rs:991
 msgid "Run"
 msgstr "Lancer"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:988
+#: src/main.rs:1007
 msgid "Remove From Menu"
 msgstr "Supprimer du menu"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1005
+#: src/main.rs:1024
 msgid "Add To Menu"
 msgstr "Ajouter au menu"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1036
+#: src/main.rs:1055
 msgid "App Exported!"
 msgstr "Application exportée !"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1042
+#: src/main.rs:1061
 msgid "App Removed!"
 msgstr "Application supprimée !"
 
 #. TRANSLATORS: Confirmation Dialogue
-#: src/main.rs:1053
+#: src/main.rs:1072
 msgid "Really Delete?"
 msgstr "Confirmer la suppression ?"
 
 #. TRANSLATORS: Confirmation Dialogue - {} replaced with the name of the Distrobox
-#: src/main.rs:1055
+#: src/main.rs:1074
 msgid "Are you sure you want to delete {}?"
 msgstr "Êtes-vous certain de vouloir supprimer {} ?"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1061
+#: src/main.rs:1080
 msgid "Delete"
 msgstr "Supprimer"
 
 #. TRANSLATORS: Success Text
-#: src/main.rs:1074
+#: src/main.rs:1093
 msgid "Box Deleted!"
 msgstr "Box supprimée !"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1096 src/main.rs:1100
+#: src/main.rs:1115 src/main.rs:1119
 msgid "Clone"
 msgstr "Cloner"
 
 #. TRANSLATORS: Title / Instruction label
-#: src/main.rs:1126
+#: src/main.rs:1145
 msgid "Enter the name of your new box"
 msgstr "Entrez le nom de votre nouvelle Box"
 
-#: src/main.rs:1130
+#: src/main.rs:1149
 msgid "Note: Cloning can take a long time, please be patient"
 msgstr "Note : cloner peut prendre un certain temps, merci d’être patient"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1211
+#: src/main.rs:1230
 msgid "Please install one of the supported terminals:"
 msgstr "Veuillez installer l’un des terminaux supportés :"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1216
+#: src/main.rs:1235
 msgid "No supported terminal found"
 msgstr "Aucun terminal supporté trouvé"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1221 src/main.rs:1259 src/main.rs:1277 src/main.rs:1313
-#: src/main.rs:1492 src/main.rs:1514
+#: src/main.rs:1240 src/main.rs:1278 src/main.rs:1296 src/main.rs:1332
+#: src/main.rs:1511 src/main.rs:1533
 msgid "Ok"
 msgstr "Ok"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1234
+#: src/main.rs:1253
 msgid "No Boxes"
 msgstr "Pas de Boxs"
 
 #. TRANSLATORS: Instructions
-#: src/main.rs:1237
+#: src/main.rs:1256
 msgid "Click the + at the top-left to create your first box!"
 msgstr "Cliquez sur le + en haut à gauche pour créer votre première Box !"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1249
+#: src/main.rs:1268
 msgid ""
 "You appear to be using a Flatpak of BoxBuddy without filesystem access. If "
 "you wish to set a Custom Home Directory you will need to grant filesystem "
@@ -319,12 +319,12 @@ msgstr ""
 "de détails.</a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1253
+#: src/main.rs:1272
 msgid "Sandboxed Flatpak Detected"
 msgstr "Flatpak isolé dans un bac à sable (sandbox)"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1268
+#: src/main.rs:1287
 msgid ""
 "Distrobox can already access folders in your home directory - even if you "
 "have specified a custom home folder"
@@ -333,57 +333,57 @@ msgstr ""
 "personnel – même si vous avez spécifié un répertoire personnel personnalisé"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1272
+#: src/main.rs:1291
 msgid "Volume is already accessible"
 msgstr "Volume déjà accessible"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1302
+#: src/main.rs:1321
 msgid "You don't appear to have any boxes which can install {} files"
 msgstr ""
 "Il semble que vous n’ayez aucune Box susceptible d’installer des fichiers {}"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1308
+#: src/main.rs:1327
 msgid "No Suitable Boxes Found"
 msgstr "Aucune Box appropriée trouvée"
 
 #. TRANSLATORS: Popup Window Title - {} replaced with .deb or .rpm
-#: src/main.rs:1322
+#: src/main.rs:1341
 msgid "Install {} File"
 msgstr "Installer un fichier {}"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1330
+#: src/main.rs:1349
 msgid "Install"
 msgstr "Installer"
 
 #. TRANSLATORS: Info message - {} replaced with a file path
-#: src/main.rs:1354
+#: src/main.rs:1373
 msgid "Installing: {}"
 msgstr "Installation de {}"
 
-#: src/main.rs:1358
+#: src/main.rs:1377
 msgid "Select a box to install this file into:"
 msgstr "Sélectionnez une Box dans laquelle installer ce fichier :"
 
 #. TRANSLATORS - Label for Dropdown of existing Boxes to install .deb or .rpm into
-#: src/main.rs:1376
+#: src/main.rs:1395
 msgid "Box"
 msgstr "Box"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1414
+#: src/main.rs:1433
 msgid "DEB Files"
 msgstr "Fichiers DEB"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1449
+#: src/main.rs:1468
 msgid "RPM Files"
 msgstr "Fichiers RPM"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1482
+#: src/main.rs:1501
 msgid ""
 "This file is not accessible to Flatpak - please copy it to your Downloads "
 "folder, or allow filesystem access. Please see the <a href='https://dvlv."
@@ -395,46 +395,46 @@ msgstr ""
 "tips'>documentation pour plus de détails.</a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1486
+#: src/main.rs:1505
 msgid "File Not Accessible"
 msgstr "Fichier inaccessible"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1505
+#: src/main.rs:1524
 msgid "This file does not appear to be a {} file"
 msgstr "Ce fichier ne semble pas être un fichier {}"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1509
+#: src/main.rs:1528
 msgid "Incorrect File Type"
 msgstr "Type de fichier incorrect"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:1537
+#: src/main.rs:1556
 msgid "Preferred Terminal"
 msgstr "Terminal préféré"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1545
+#: src/main.rs:1564
 msgid "Save"
 msgstr "Sauvegarder"
 
 #. TRANSLATORS: Instructions label
-#: src/main.rs:1566
+#: src/main.rs:1585
 msgid "Select your preferred terminal"
 msgstr "Sélectionnez votre terminal préféré"
 
 #. TRANSLATORS: Label for Dropdown of terminals available
-#: src/main.rs:1586
+#: src/main.rs:1605
 msgid "Terminal"
 msgstr "Terminal"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1606
+#: src/main.rs:1627
 msgid "Terminal Preference Saved!"
 msgstr "Terminal préféré sauvegardé !"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1618
+#: src/main.rs:1638
 msgid "Sorry, Preference Could Not Be Saved"
 msgstr "Désolé, vos préférences n’ont pas pu être sauvegardées"

--- a/po/hi/LC_MESSAGES/hi.po
+++ b/po/hi/LC_MESSAGES/hi.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: BoxBuddyRS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-13 08:11+0000\n"
+"POT-Creation-Date: 2024-06-14 07:12+0000\n"
 "PO-Revision-Date: 2024-06-13 10:18+0200\n"
 "Last-Translator: Scrambled777 <weblate.scrambled777@simplelogin.com>\n"
 "Language-Team: Hindi <indlinux-hindi@lists.sourceforge.net>\n"
@@ -20,406 +20,411 @@ msgstr ""
 "X-Generator: Poedit 3.4.4\n"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:139
+#: src/main.rs:150
 msgid "Create A Distrobox"
 msgstr "एक Distrobox बनाएं"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:158
+#: src/main.rs:169
 msgid "Assemble A Distrobox"
 msgstr "एक Distrobox संकलित करें"
 
 #. TRANSLATORS: File type
-#: src/main.rs:164
+#: src/main.rs:175
 msgid "INI-Files"
 msgstr "INI-फाइलें"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:185
+#: src/main.rs:196
 msgid "Menu"
 msgstr "मेनू"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:238
+#: src/main.rs:249
 msgid "Refresh"
 msgstr "ताज़ा करें"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:244
+#: src/main.rs:255
 msgid "Set Preferred Terminal"
 msgstr "पसंदीदा टर्मिनल निर्धारित करें"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:251
+#: src/main.rs:262
 msgid "About BoxBuddy"
 msgstr "BoxBuddy के बारे में"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:256
+#: src/main.rs:267
 msgid "Quit"
 msgstr "छोड़ें"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:264
+#: src/main.rs:275
 msgid "Distrobox not found!"
 msgstr "Distrobox नहीं मिला!"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:269
+#: src/main.rs:280
 msgid "Distrobox could not be found, please ensure it is installed!"
 msgstr "Distrobox नहीं मिला, कृपया सुनिश्चित करें कि यह स्थापित है!"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:341
+#: src/main.rs:352
 msgid "Stop Box"
 msgstr "बॉक्स बंद करें"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:370
+#: src/main.rs:381
 msgid "Open Terminal"
 msgstr "टर्मिनल खोलें"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:383
+#: src/main.rs:394
 msgid "Upgrade Box"
 msgstr "बॉक्स उन्नयन करें"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:395
+#: src/main.rs:406
 msgid "View Applications"
 msgstr "अनुप्रयोग देखें"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:418
+#: src/main.rs:429
 msgid "Delete Box"
 msgstr "बॉक्स मिटाएं"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:431
+#: src/main.rs:442
 msgid "Clone Box"
 msgstr "बॉक्स का प्रतिरूप बनाएं"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:451
+#: src/main.rs:462
 msgid "Install .deb File"
 msgstr ".deb फाइल स्थापित करें"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:463
+#: src/main.rs:474
 msgid "Install .rpm File"
 msgstr ".rpm फाइल स्थापित करें"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:512 src/main.rs:570
+#: src/main.rs:523 src/main.rs:581
 msgid "Create New Distrobox"
 msgstr "नया Distrobox बनाएं"
 
 #. TRANSLATORS: Context label of the application doing something
-#: src/main.rs:524
+#: src/main.rs:535
 msgid "Assembling Distroboxes, please wait..."
 msgstr "Distrobox संकलित किया जा रहा है, कृपया प्रतीक्षा करें..."
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:578
+#: src/main.rs:589
 msgid "Create"
 msgstr "बनाएं"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:583
+#: src/main.rs:594
 msgid "Additional Information"
 msgstr "अतिरिक्त जानकारी"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:588 src/main.rs:1060 src/main.rs:1105 src/main.rs:1335 src/main.rs:1550
+#: src/main.rs:599 src/main.rs:1078 src/main.rs:1123 src/main.rs:1353
+#: src/main.rs:1568
 msgid "Cancel"
 msgstr "रद्द करें"
 
 #. TRANSLATORS: Entry Label - Name input for new distrobox
-#: src/main.rs:622 src/main.rs:1143
+#: src/main.rs:633 src/main.rs:1161
 msgid "Name"
 msgstr "नाम"
 
 #. TRANSLATORS: Entry Label - Select home directory for new distrobox
-#: src/main.rs:643
+#: src/main.rs:654
 msgid "Home Directory (Leave blank for default)"
 msgstr "होम निर्देशिका (तयशुदा के लिए खाली छोड़ें)"
 
 #. TRANSLATORS - Label for Dropdown where the user selects the container image to create
-#: src/main.rs:676
+#: src/main.rs:687
 msgid "Image"
 msgstr "छवि"
 
 #. TRANSLATORS - Label for Toggle when creating box to add systemd support
-#: src/main.rs:683
+#: src/main.rs:694
 msgid "Use init system"
 msgstr "init प्रणाली का प्रयोग करें"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:790
+#: src/main.rs:801
 msgid "Add a volume"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:803
+#: src/main.rs:814
 msgid "Remove volume"
 msgstr ""
 
 #. TRANSLATORS: Help text for volume input
-#: src/main.rs:816
+#: src/main.rs:827
 msgid "Enter the location to mount this folder inside your new box"
 msgstr "इस फोल्डर को अपने नए बॉक्स के अंदर संलग्न करने के लिए स्थान दर्ज करें"
 
 #. TRANSLATORS: Subheading
-#: src/main.rs:840
+#: src/main.rs:851
 msgid "Additional Volumes:"
 msgstr "अतिरिक्त वॉल्यूम:"
 
 #. TRANSLATORS: Context for the Additional Volumes subheading
-#: src/main.rs:843
+#: src/main.rs:854
 msgid "Additional directories the new box should be able to access"
 msgstr "अतिरिक्त निर्देशिकाएं जिन तक नए बॉक्स की पहुंच होनी चाहिए"
 
-#. TRANSLATORS: About section
-#: src/main.rs:868
+#. TRANSLATORS: Description of the application
+#: src/main.rs:878
 msgid ""
 "A Graphical Manager for your Distroboxes.\n"
 "    \n"
-"BoxBuddy is not partnered with or endorsed by any linux distributions or companies.\n"
+"BoxBuddy is not partnered with or endorsed by any linux distributions or "
+"companies.\n"
 "    \n"
-"Trademarks, service marks, and logos are the property of their respective owners."
+"Trademarks, service marks, and logos are the property of their respective "
+"owners."
 msgstr ""
 
 #. TRANSLATORS: Window Title - shows list of installed applications in distrobox
-#: src/main.rs:894
+#: src/main.rs:912
 msgid "Installed Applications"
 msgstr "स्थापित अनुप्रयोग"
 
 #. TRANSLATORS: Loading Message
-#: src/main.rs:912
+#: src/main.rs:930
 msgid "Loading..."
 msgstr "लोड हो रहा है..."
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:955
+#: src/main.rs:973
 msgid "No Applications Installed"
 msgstr "कोई अनुप्रयोग स्थापित नहीं है"
 
 #. TRANSLATORS: Window Title
-#: src/main.rs:960
+#: src/main.rs:978
 msgid "Available Applications"
 msgstr "उपलब्ध अनुप्रयोग"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:973
+#: src/main.rs:991
 msgid "Run"
 msgstr "चलायें"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:989
+#: src/main.rs:1007
 msgid "Remove From Menu"
 msgstr "मेनू से हटाएं"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1006
+#: src/main.rs:1024
 msgid "Add To Menu"
 msgstr "मेनू में जोड़ें"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1037
+#: src/main.rs:1055
 msgid "App Exported!"
 msgstr "ऐप निर्यातित!"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1043
+#: src/main.rs:1061
 msgid "App Removed!"
 msgstr "ऐप हटाया गया!"
 
 #. TRANSLATORS: Confirmation Dialogue
-#: src/main.rs:1054
+#: src/main.rs:1072
 msgid "Really Delete?"
 msgstr "सचमुच मिटाएं?"
 
 #. TRANSLATORS: Confirmation Dialogue - {} replaced with the name of the Distrobox
-#: src/main.rs:1056
+#: src/main.rs:1074
 msgid "Are you sure you want to delete {}?"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1062
+#: src/main.rs:1080
 msgid "Delete"
 msgstr "मिटाएं"
 
 #. TRANSLATORS: Success Text
-#: src/main.rs:1075
+#: src/main.rs:1093
 msgid "Box Deleted!"
 msgstr "बॉक्स मिटा दिया गया!"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1097 src/main.rs:1101
+#: src/main.rs:1115 src/main.rs:1119
 msgid "Clone"
 msgstr "प्रतिरूपित करें"
 
 #. TRANSLATORS: Title / Instruction label
-#: src/main.rs:1127
+#: src/main.rs:1145
 msgid "Enter the name of your new box"
 msgstr "अपने नए बॉक्स का नाम दर्ज करें"
 
-#: src/main.rs:1131
+#: src/main.rs:1149
 msgid "Note: Cloning can take a long time, please be patient"
 msgstr "ध्यान दें: प्रतिरूपण में लंबा समय लग सकता है, कृपया धैर्य रखें"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1212
+#: src/main.rs:1230
 msgid "Please install one of the supported terminals:"
 msgstr "कृपया समर्थित टर्मिनलों में से एक स्थापित करें:"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1217
+#: src/main.rs:1235
 msgid "No supported terminal found"
 msgstr "कोई समर्थित टर्मिनल नहीं मिला"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1222 src/main.rs:1260 src/main.rs:1278 src/main.rs:1314 src/main.rs:1493
-#: src/main.rs:1515
+#: src/main.rs:1240 src/main.rs:1278 src/main.rs:1296 src/main.rs:1332
+#: src/main.rs:1511 src/main.rs:1533
 msgid "Ok"
 msgstr "ठीक है"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1235
+#: src/main.rs:1253
 msgid "No Boxes"
 msgstr "कोई बॉक्स नहीं"
 
 #. TRANSLATORS: Instructions
-#: src/main.rs:1238
+#: src/main.rs:1256
 msgid "Click the + at the top-left to create your first box!"
 msgstr "अपना पहला बॉक्स बनाने के लिए शीर्ष-बाएं पर + पर दबाएं!"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1250
+#: src/main.rs:1268
 msgid ""
-"You appear to be using a Flatpak of BoxBuddy without filesystem access. If you wish to "
-"set a Custom Home Directory you will need to grant filesystem access. Please see the <a "
-"href='https://dvlv.github.io/BoxBuddyRS/tips'>documentation for details.</a>"
+"You appear to be using a Flatpak of BoxBuddy without filesystem access. If "
+"you wish to set a Custom Home Directory you will need to grant filesystem "
+"access. Please see the <a href='https://dvlv.github.io/BoxBuddyRS/"
+"tips'>documentation for details.</a>"
 msgstr ""
-"ऐसा प्रतीत होता है कि आप बिना फाइल प्रणाली पहुंच के BoxBuddy के Flatpak का उपयोग कर रहे हैं। यदि "
-"आप एक तदनुकूल होम निर्देशिका निर्धारित करना चाहते हैं तो आपको फाइल प्रणाली पहुंच प्रदान करनी होगी। "
-"कृपया विवरण के लिए <a href='https://dvlv.github.io/BoxBuddyRS/tips'>दस्तावेज़ देखें।</a>"
+"ऐसा प्रतीत होता है कि आप बिना फाइल प्रणाली पहुंच के BoxBuddy के Flatpak का उपयोग कर "
+"रहे हैं। यदि आप एक तदनुकूल होम निर्देशिका निर्धारित करना चाहते हैं तो आपको फाइल प्रणाली "
+"पहुंच प्रदान करनी होगी। कृपया विवरण के लिए <a href='https://dvlv.github.io/"
+"BoxBuddyRS/tips'>दस्तावेज़ देखें।</a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1254
+#: src/main.rs:1272
 msgid "Sandboxed Flatpak Detected"
 msgstr "सैंडबॉक्स्ड Flatpak का पता चला"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1269
+#: src/main.rs:1287
 msgid ""
-"Distrobox can already access folders in your home directory - even if you have specified "
-"a custom home folder"
+"Distrobox can already access folders in your home directory - even if you "
+"have specified a custom home folder"
 msgstr ""
-"Distrobox पहले से ही आपकी होम निर्देशिका में फोल्डरों तक पहुंच सकता है - भले ही आपने एक तदनुकूल होम "
-"फोल्डर निर्दिष्ट किया हो"
+"Distrobox पहले से ही आपकी होम निर्देशिका में फोल्डरों तक पहुंच सकता है - भले ही आपने एक "
+"तदनुकूल होम फोल्डर निर्दिष्ट किया हो"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1273
+#: src/main.rs:1291
 msgid "Volume is already accessible"
 msgstr "वॉल्यूम पहले से ही पहुंच योग्य है"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1303
+#: src/main.rs:1321
 msgid "You don't appear to have any boxes which can install {} files"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1309
+#: src/main.rs:1327
 msgid "No Suitable Boxes Found"
 msgstr "कोई उपयुक्त बॉक्स नहीं मिला"
 
 #. TRANSLATORS: Popup Window Title - {} replaced with .deb or .rpm
-#: src/main.rs:1323
+#: src/main.rs:1341
 msgid "Install {} File"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1331
+#: src/main.rs:1349
 msgid "Install"
 msgstr "स्थापित करें"
 
 #. TRANSLATORS: Info message - {} replaced with a file path
-#: src/main.rs:1355
+#: src/main.rs:1373
 msgid "Installing: {}"
 msgstr ""
 
-#: src/main.rs:1359
+#: src/main.rs:1377
 msgid "Select a box to install this file into:"
 msgstr "इस फाइल को स्थापित करने के लिए एक बॉक्स का चयन करें:"
 
 #. TRANSLATORS - Label for Dropdown of existing Boxes to install .deb or .rpm into
-#: src/main.rs:1377
+#: src/main.rs:1395
 msgid "Box"
 msgstr "बॉक्स"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1415
+#: src/main.rs:1433
 msgid "DEB Files"
 msgstr "DEB फाइलें"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1450
+#: src/main.rs:1468
 msgid "RPM Files"
 msgstr "RPM फाइलें"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1483
+#: src/main.rs:1501
 msgid ""
-"This file is not accessible to Flatpak - please copy it to your Downloads folder, or "
-"allow filesystem access. Please see the <a href='https://dvlv.github.io/BoxBuddyRS/"
-"tips'>documentation for details.</a>"
+"This file is not accessible to Flatpak - please copy it to your Downloads "
+"folder, or allow filesystem access. Please see the <a href='https://dvlv."
+"github.io/BoxBuddyRS/tips'>documentation for details.</a>"
 msgstr ""
-"यह फाइल Flatpak तक पहुंच योग्य नहीं है - कृपया इसे अपने डाउनलोड फोल्डर में कॉपी करें, या फाइल प्रणाली "
-"तक पहुंच की अनुमति दें। कृपया विवरण के लिए <a href='https://dvlv.github.io/BoxBuddyRS/"
-"tips'>दस्तावेज़ देखें।</a>"
+"यह फाइल Flatpak तक पहुंच योग्य नहीं है - कृपया इसे अपने डाउनलोड फोल्डर में कॉपी करें, या "
+"फाइल प्रणाली तक पहुंच की अनुमति दें। कृपया विवरण के लिए <a href='https://dvlv.github."
+"io/BoxBuddyRS/tips'>दस्तावेज़ देखें।</a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1487
+#: src/main.rs:1505
 msgid "File Not Accessible"
 msgstr "फाइल पहुंच योग्य नहीं"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1506
+#: src/main.rs:1524
 msgid "This file does not appear to be a {} file"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1510
+#: src/main.rs:1528
 msgid "Incorrect File Type"
 msgstr "गलत फाइल प्रकार"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:1538
+#: src/main.rs:1556
 msgid "Preferred Terminal"
 msgstr "पसंदीदा टर्मिनल"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1546
+#: src/main.rs:1564
 msgid "Save"
 msgstr "सहेजें"
 
 #. TRANSLATORS: Instructions label
-#: src/main.rs:1567
+#: src/main.rs:1585
 msgid "Select your preferred terminal"
 msgstr "अपना पसंदीदा टर्मिनल चुनें"
 
 #. TRANSLATORS: Label for Dropdown of terminals available
-#: src/main.rs:1587
+#: src/main.rs:1605
 msgid "Terminal"
 msgstr "टर्मिनल"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1607
+#: src/main.rs:1627
 msgid "Terminal Preference Saved!"
 msgstr "टर्मिनल प्राथमिकता सहेजी गई!"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1619
+#: src/main.rs:1638
 msgid "Sorry, Preference Could Not Be Saved"
 msgstr "क्षमा करें, प्राथमिकता सहेजी नहीं जा सकी"

--- a/po/it_IT/LC_MESSAGES/it_IT.po
+++ b/po/it_IT/LC_MESSAGES/it_IT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: boxbuddyRS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-13 08:56+0000\n"
+"POT-Creation-Date: 2024-06-14 07:12+0000\n"
 "PO-Revision-Date: 2024-06-13 10:59+0200\n"
 "Last-Translator: Albano Battistella <albanobattistella@gmail.com>\n"
 "Language-Team: \n"
@@ -19,182 +19,182 @@ msgstr ""
 
 # Button Label
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:139
+#: src/main.rs:150
 msgid "Create A Distrobox"
 msgstr "Crea una Distrobox"
 
 # Button Label
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:158
+#: src/main.rs:169
 msgid "Assemble A Distrobox"
 msgstr "Assembla una Distrobox"
 
 #. TRANSLATORS: File type
-#: src/main.rs:164
+#: src/main.rs:175
 msgid "INI-Files"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:185
+#: src/main.rs:196
 msgid "Menu"
 msgstr ""
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:238
+#: src/main.rs:249
 msgid "Refresh"
 msgstr ""
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:244
+#: src/main.rs:255
 msgid "Set Preferred Terminal"
 msgstr ""
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:251
+#: src/main.rs:262
 msgid "About BoxBuddy"
 msgstr "Informazioni su BoxBuddy"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:256
+#: src/main.rs:267
 msgid "Quit"
 msgstr ""
 
 # Error Message
 #. TRANSLATORS: Error message
-#: src/main.rs:264
+#: src/main.rs:275
 msgid "Distrobox not found!"
 msgstr "Nessuna Distrobox trovata!"
 
 # Error Message
 #. TRANSLATORS: Error message
-#: src/main.rs:269
+#: src/main.rs:280
 msgid "Distrobox could not be found, please ensure it is installed!"
 msgstr "Impossibile trovare Distrobox, assicurati che sia installato!"
 
 # Error Message
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:341
+#: src/main.rs:352
 msgid "Stop Box"
 msgstr ""
 
 # Button
 #. TRANSLATORS: Row Label
-#: src/main.rs:370
+#: src/main.rs:381
 msgid "Open Terminal"
 msgstr "Apri il terminale"
 
 # Button
 #. TRANSLATORS: Row Label
-#: src/main.rs:383
+#: src/main.rs:394
 msgid "Upgrade Box"
 msgstr "Casella di aggiornamento"
 
 # Button
 #. TRANSLATORS: Row Label
-#: src/main.rs:395
+#: src/main.rs:406
 msgid "View Applications"
 msgstr "Visualizza applicazioni"
 
 # Button
 #. TRANSLATORS: Row Label
-#: src/main.rs:418
+#: src/main.rs:429
 msgid "Delete Box"
 msgstr "Rimuovere la scatola"
 
 # Button
 #. TRANSLATORS: Row Label
-#: src/main.rs:431
+#: src/main.rs:442
 msgid "Clone Box"
 msgstr "Clonare la scatola"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:451
+#: src/main.rs:462
 msgid "Install .deb File"
 msgstr ""
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:463
+#: src/main.rs:474
 msgid "Install .rpm File"
 msgstr ""
 
 # Button Tooltip
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:512 src/main.rs:570
+#: src/main.rs:523 src/main.rs:581
 msgid "Create New Distrobox"
 msgstr "Crea nuova Distrobox"
 
 #. TRANSLATORS: Context label of the application doing something
-#: src/main.rs:524
+#: src/main.rs:535
 msgid "Assembling Distroboxes, please wait..."
 msgstr ""
 
 # Button
 #. TRANSLATORS: Button Label
-#: src/main.rs:578
+#: src/main.rs:589
 msgid "Create"
 msgstr "Crea"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:583
+#: src/main.rs:594
 msgid "Additional Information"
 msgstr ""
 
 # Button
 #. TRANSLATORS: Button Label
-#: src/main.rs:588 src/main.rs:1059 src/main.rs:1104 src/main.rs:1334
-#: src/main.rs:1549
+#: src/main.rs:599 src/main.rs:1078 src/main.rs:1123 src/main.rs:1353
+#: src/main.rs:1568
 msgid "Cancel"
 msgstr "Annulla"
 
 # Label - name of new Distrobox
 #. TRANSLATORS: Entry Label - Name input for new distrobox
-#: src/main.rs:622 src/main.rs:1142
+#: src/main.rs:633 src/main.rs:1161
 msgid "Name"
 msgstr "Nome"
 
 #. TRANSLATORS: Entry Label - Select home directory for new distrobox
-#: src/main.rs:643
+#: src/main.rs:654
 msgid "Home Directory (Leave blank for default)"
 msgstr "Directory principale (lasciare vuoto per impostazione predefinita)"
 
 # Label - Container image for new Distrobox
 #. TRANSLATORS - Label for Dropdown where the user selects the container image to create
-#: src/main.rs:676
+#: src/main.rs:687
 msgid "Image"
 msgstr "Immagine"
 
 #. TRANSLATORS - Label for Toggle when creating box to add systemd support
-#: src/main.rs:683
+#: src/main.rs:694
 msgid "Use init system"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:790
+#: src/main.rs:801
 msgid "Add a volume"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:803
+#: src/main.rs:814
 msgid "Remove volume"
 msgstr ""
 
 #. TRANSLATORS: Help text for volume input
-#: src/main.rs:816
+#: src/main.rs:827
 msgid "Enter the location to mount this folder inside your new box"
 msgstr ""
 
 #. TRANSLATORS: Subheading
-#: src/main.rs:840
+#: src/main.rs:851
 msgid "Additional Volumes:"
 msgstr ""
 
 #. TRANSLATORS: Context for the Additional Volumes subheading
-#: src/main.rs:843
+#: src/main.rs:854
 msgid "Additional directories the new box should be able to access"
 msgstr ""
 
 #. TRANSLATORS: Description of the application
-#: src/main.rs:867
+#: src/main.rs:878
 msgid ""
 "A Graphical Manager for your Distroboxes.\n"
 "    \n"
@@ -207,128 +207,128 @@ msgstr ""
 
 # Button
 #. TRANSLATORS: Window Title - shows list of installed applications in distrobox
-#: src/main.rs:893
+#: src/main.rs:912
 msgid "Installed Applications"
 msgstr "Applicazioni installate"
 
 # Message
 #. TRANSLATORS: Loading Message
-#: src/main.rs:911
+#: src/main.rs:930
 msgid "Loading..."
 msgstr "Caricamento..."
 
 # Error Message
 #. TRANSLATORS: Error Message
-#: src/main.rs:954
+#: src/main.rs:973
 msgid "No Applications Installed"
 msgstr "Nessuna applicazione installata"
 
 # Button
 #. TRANSLATORS: Window Title
-#: src/main.rs:959
+#: src/main.rs:978
 msgid "Available Applications"
 msgstr "Applicazioni disponibili"
 
 # Button - Execute an application in a box
 #. TRANSLATORS: Button Label
-#: src/main.rs:972
+#: src/main.rs:991
 msgid "Run"
 msgstr "Esegui"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:988
+#: src/main.rs:1007
 msgid "Remove From Menu"
 msgstr "Rimuovere dal menu"
 
 # Button
 #. TRANSLATORS: Button Label
-#: src/main.rs:1005
+#: src/main.rs:1024
 msgid "Add To Menu"
 msgstr "Aggiungi al menù"
 
 # Success Message
 #. TRANSLATORS: Success Message
-#: src/main.rs:1036
+#: src/main.rs:1055
 msgid "App Exported!"
 msgstr "App esportata!"
 
 # Success Message
 #. TRANSLATORS: Success Message
-#: src/main.rs:1042
+#: src/main.rs:1061
 msgid "App Removed!"
 msgstr "App rimossa!"
 
 # Confirmation Message
 #. TRANSLATORS: Confirmation Dialogue
-#: src/main.rs:1053
+#: src/main.rs:1072
 msgid "Really Delete?"
 msgstr "Cancellare veramente?"
 
 # Confirmation Message - has box name appended at the end
 #. TRANSLATORS: Confirmation Dialogue - {} replaced with the name of the Distrobox
-#: src/main.rs:1055
+#: src/main.rs:1074
 msgid "Are you sure you want to delete {}?"
 msgstr "Sei sicuro di voler eliminare {} ?"
 
 # Button
 #. TRANSLATORS: Button Label
-#: src/main.rs:1061
+#: src/main.rs:1080
 msgid "Delete"
 msgstr "Cancella"
 
 # Success Message
 #. TRANSLATORS: Success Text
-#: src/main.rs:1074
+#: src/main.rs:1093
 msgid "Box Deleted!"
 msgstr "Scatola eliminata!"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1096 src/main.rs:1100
+#: src/main.rs:1115 src/main.rs:1119
 msgid "Clone"
 msgstr ""
 
 #. TRANSLATORS: Title / Instruction label
-#: src/main.rs:1126
+#: src/main.rs:1145
 msgid "Enter the name of your new box"
 msgstr ""
 
-#: src/main.rs:1130
+#: src/main.rs:1149
 msgid "Note: Cloning can take a long time, please be patient"
 msgstr ""
 
 # Error Message - has list of supported terminals appended
 #. TRANSLATORS: Error Message
-#: src/main.rs:1211
+#: src/main.rs:1230
 msgid "Please install one of the supported terminals:"
 msgstr "Installa uno dei terminali supportati:"
 
 # Error message
 #. TRANSLATORS: Error Message
-#: src/main.rs:1216
+#: src/main.rs:1235
 msgid "No supported terminal found"
 msgstr "Nessun terminale supportato trovato"
 
 # Button
 #. TRANSLATORS: Button Label
-#: src/main.rs:1221 src/main.rs:1259 src/main.rs:1277 src/main.rs:1313
-#: src/main.rs:1492 src/main.rs:1514
+#: src/main.rs:1240 src/main.rs:1278 src/main.rs:1296 src/main.rs:1332
+#: src/main.rs:1511 src/main.rs:1533
 msgid "Ok"
 msgstr "Ok"
 
 # Error Message
 #. TRANSLATORS: Error Message
-#: src/main.rs:1234
+#: src/main.rs:1253
 msgid "No Boxes"
 msgstr "Nessuna scatola"
 
 # Help Text
 #. TRANSLATORS: Instructions
-#: src/main.rs:1237
+#: src/main.rs:1256
 msgid "Click the + at the top-left to create your first box!"
 msgstr "Clicca sul + in alto a sinistra per creare la tua prima scatola!"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1249
+#: src/main.rs:1268
 msgid ""
 "You appear to be using a Flatpak of BoxBuddy without filesystem access. If "
 "you wish to set a Custom Home Directory you will need to grant filesystem "
@@ -337,68 +337,68 @@ msgid ""
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1253
+#: src/main.rs:1272
 msgid "Sandboxed Flatpak Detected"
 msgstr ""
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1268
+#: src/main.rs:1287
 msgid ""
 "Distrobox can already access folders in your home directory - even if you "
 "have specified a custom home folder"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1272
+#: src/main.rs:1291
 msgid "Volume is already accessible"
 msgstr ""
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1302
+#: src/main.rs:1321
 msgid "You don't appear to have any boxes which can install {} files"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1308
+#: src/main.rs:1327
 msgid "No Suitable Boxes Found"
 msgstr ""
 
 #. TRANSLATORS: Popup Window Title - {} replaced with .deb or .rpm
-#: src/main.rs:1322
+#: src/main.rs:1341
 msgid "Install {} File"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1330
+#: src/main.rs:1349
 msgid "Install"
 msgstr ""
 
 #. TRANSLATORS: Info message - {} replaced with a file path
-#: src/main.rs:1354
+#: src/main.rs:1373
 msgid "Installing: {}"
 msgstr ""
 
-#: src/main.rs:1358
+#: src/main.rs:1377
 msgid "Select a box to install this file into:"
 msgstr ""
 
 #. TRANSLATORS - Label for Dropdown of existing Boxes to install .deb or .rpm into
-#: src/main.rs:1376
+#: src/main.rs:1395
 msgid "Box"
 msgstr ""
 
 #. TRANSLATORS: File type
-#: src/main.rs:1414
+#: src/main.rs:1433
 msgid "DEB Files"
 msgstr ""
 
 #. TRANSLATORS: File type
-#: src/main.rs:1449
+#: src/main.rs:1468
 msgid "RPM Files"
 msgstr ""
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1482
+#: src/main.rs:1501
 msgid ""
 "This file is not accessible to Flatpak - please copy it to your Downloads "
 "folder, or allow filesystem access. Please see the <a href='https://dvlv."
@@ -406,48 +406,48 @@ msgid ""
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1486
+#: src/main.rs:1505
 msgid "File Not Accessible"
 msgstr ""
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1505
+#: src/main.rs:1524
 msgid "This file does not appear to be a {} file"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1509
+#: src/main.rs:1528
 msgid "Incorrect File Type"
 msgstr ""
 
 # Button
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:1537
+#: src/main.rs:1556
 msgid "Preferred Terminal"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1545
+#: src/main.rs:1564
 msgid "Save"
 msgstr ""
 
 #. TRANSLATORS: Instructions label
-#: src/main.rs:1566
+#: src/main.rs:1585
 msgid "Select your preferred terminal"
 msgstr ""
 
 # Button
 #. TRANSLATORS: Label for Dropdown of terminals available
-#: src/main.rs:1586
+#: src/main.rs:1605
 msgid "Terminal"
 msgstr "Terminale"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1606
+#: src/main.rs:1627
 msgid "Terminal Preference Saved!"
 msgstr ""
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1618
+#: src/main.rs:1638
 msgid "Sorry, Preference Could Not Be Saved"
 msgstr ""

--- a/po/pt_BR/LC_MESSAGES/pt_BR.po
+++ b/po/pt_BR/LC_MESSAGES/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-13 08:56+0000\n"
+"POT-Creation-Date: 2024-06-14 07:12+0000\n"
 "PO-Revision-Date: 2024-06-13 10:59+0200\n"
 "Last-Translator: Luiz Lima\n"
 "Language-Team: \n"
@@ -19,168 +19,168 @@ msgstr ""
 "X-Generator: Poedit 3.4.4\n"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:139
+#: src/main.rs:150
 msgid "Create A Distrobox"
 msgstr "Criar uma Distrobox"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:158
+#: src/main.rs:169
 msgid "Assemble A Distrobox"
 msgstr "Montar uma Distrobox"
 
 #. TRANSLATORS: File type
-#: src/main.rs:164
+#: src/main.rs:175
 msgid "INI-Files"
 msgstr "INI-Files"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:185
+#: src/main.rs:196
 msgid "Menu"
 msgstr "Menu"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:238
+#: src/main.rs:249
 msgid "Refresh"
 msgstr "Recarregar"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:244
+#: src/main.rs:255
 msgid "Set Preferred Terminal"
 msgstr "Definir Terminal Preferido"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:251
+#: src/main.rs:262
 msgid "About BoxBuddy"
 msgstr "Sobre o BoxBuddy"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:256
+#: src/main.rs:267
 msgid "Quit"
 msgstr "Sair"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:264
+#: src/main.rs:275
 msgid "Distrobox not found!"
 msgstr "Distrobox não encontrada!"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:269
+#: src/main.rs:280
 msgid "Distrobox could not be found, please ensure it is installed!"
 msgstr "Distrobox não foi encontrado, por favor garanta que esteja instalado!"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:341
+#: src/main.rs:352
 msgid "Stop Box"
 msgstr "Parar Caixa"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:370
+#: src/main.rs:381
 msgid "Open Terminal"
 msgstr "Abrir Terminal"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:383
+#: src/main.rs:394
 msgid "Upgrade Box"
 msgstr "Atualizar Caixa"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:395
+#: src/main.rs:406
 msgid "View Applications"
 msgstr "Ver Aplicações"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:418
+#: src/main.rs:429
 msgid "Delete Box"
 msgstr "Deletar Caixa"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:431
+#: src/main.rs:442
 msgid "Clone Box"
 msgstr "Clonar Caixa"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:451
+#: src/main.rs:462
 msgid "Install .deb File"
 msgstr "Instalar Arquivo .deb"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:463
+#: src/main.rs:474
 msgid "Install .rpm File"
 msgstr "Instalar Arquivo .rpm"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:512 src/main.rs:570
+#: src/main.rs:523 src/main.rs:581
 msgid "Create New Distrobox"
 msgstr "Criar Nova Distrobox"
 
 #. TRANSLATORS: Context label of the application doing something
-#: src/main.rs:524
+#: src/main.rs:535
 msgid "Assembling Distroboxes, please wait..."
 msgstr "Montando caixas de Distro, por favor espere..."
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:578
+#: src/main.rs:589
 msgid "Create"
 msgstr "Criar"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:583
+#: src/main.rs:594
 msgid "Additional Information"
 msgstr "Informação Adicional"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:588 src/main.rs:1059 src/main.rs:1104 src/main.rs:1334
-#: src/main.rs:1549
+#: src/main.rs:599 src/main.rs:1078 src/main.rs:1123 src/main.rs:1353
+#: src/main.rs:1568
 msgid "Cancel"
 msgstr "Cancelar"
 
 #. TRANSLATORS: Entry Label - Name input for new distrobox
-#: src/main.rs:622 src/main.rs:1142
+#: src/main.rs:633 src/main.rs:1161
 msgid "Name"
 msgstr "Nome"
 
 #. TRANSLATORS: Entry Label - Select home directory for new distrobox
-#: src/main.rs:643
+#: src/main.rs:654
 msgid "Home Directory (Leave blank for default)"
 msgstr "Diretório Home (Deixe em branco para opção padrão)"
 
 #. TRANSLATORS - Label for Dropdown where the user selects the container image to create
-#: src/main.rs:676
+#: src/main.rs:687
 msgid "Image"
 msgstr "Imagem"
 
 #. TRANSLATORS - Label for Toggle when creating box to add systemd support
-#: src/main.rs:683
+#: src/main.rs:694
 msgid "Use init system"
 msgstr "Usar sistema de inicialização"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:790
+#: src/main.rs:801
 msgid "Add a volume"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:803
+#: src/main.rs:814
 msgid "Remove volume"
 msgstr ""
 
 #. TRANSLATORS: Help text for volume input
-#: src/main.rs:816
+#: src/main.rs:827
 msgid "Enter the location to mount this folder inside your new box"
 msgstr "Insira a localização para montar esta pasta dentro da sua nova caixa"
 
 #. TRANSLATORS: Subheading
-#: src/main.rs:840
+#: src/main.rs:851
 msgid "Additional Volumes:"
 msgstr "Volumes Adicionais:"
 
 #. TRANSLATORS: Context for the Additional Volumes subheading
-#: src/main.rs:843
+#: src/main.rs:854
 msgid "Additional directories the new box should be able to access"
 msgstr "Diretórios adicionais que a nova caixa deve poder acessar"
 
 #. TRANSLATORS: Description of the application
-#: src/main.rs:867
+#: src/main.rs:878
 msgid ""
 "A Graphical Manager for your Distroboxes.\n"
 "    \n"
@@ -192,113 +192,113 @@ msgid ""
 msgstr ""
 
 #. TRANSLATORS: Window Title - shows list of installed applications in distrobox
-#: src/main.rs:893
+#: src/main.rs:912
 msgid "Installed Applications"
 msgstr "Aplicações Instaladas"
 
 #. TRANSLATORS: Loading Message
-#: src/main.rs:911
+#: src/main.rs:930
 msgid "Loading..."
 msgstr "Carregando..."
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:954
+#: src/main.rs:973
 msgid "No Applications Installed"
 msgstr "Nenhuma Aplicação Instalada"
 
 #. TRANSLATORS: Window Title
-#: src/main.rs:959
+#: src/main.rs:978
 msgid "Available Applications"
 msgstr "Aplicações Disponíveis"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:972
+#: src/main.rs:991
 msgid "Run"
 msgstr "Iniciar"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:988
+#: src/main.rs:1007
 msgid "Remove From Menu"
 msgstr "Remover do Menu"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1005
+#: src/main.rs:1024
 msgid "Add To Menu"
 msgstr "Adicionar ao Menu"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1036
+#: src/main.rs:1055
 msgid "App Exported!"
 msgstr "Aplicação Exportada!"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1042
+#: src/main.rs:1061
 msgid "App Removed!"
 msgstr "Aplicação Removida!"
 
 #. TRANSLATORS: Confirmation Dialogue
-#: src/main.rs:1053
+#: src/main.rs:1072
 msgid "Really Delete?"
 msgstr "Realmente Deletar?"
 
 #. TRANSLATORS: Confirmation Dialogue - {} replaced with the name of the Distrobox
-#: src/main.rs:1055
+#: src/main.rs:1074
 msgid "Are you sure you want to delete {}?"
 msgstr "Você tem certeza que deseja remover {} ?"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1061
+#: src/main.rs:1080
 msgid "Delete"
 msgstr "Deletar"
 
 #. TRANSLATORS: Success Text
-#: src/main.rs:1074
+#: src/main.rs:1093
 msgid "Box Deleted!"
 msgstr "Caixa Deletada!"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1096 src/main.rs:1100
+#: src/main.rs:1115 src/main.rs:1119
 msgid "Clone"
 msgstr "Clonar"
 
 #. TRANSLATORS: Title / Instruction label
-#: src/main.rs:1126
+#: src/main.rs:1145
 msgid "Enter the name of your new box"
 msgstr "Insira o nome da sua nova caixa"
 
-#: src/main.rs:1130
+#: src/main.rs:1149
 msgid "Note: Cloning can take a long time, please be patient"
 msgstr "Obs: Clonar dura muito tempo, por favor, seja paciente"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1211
+#: src/main.rs:1230
 msgid "Please install one of the supported terminals:"
 msgstr "Por favor, instale um dos terminais suportados:"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1216
+#: src/main.rs:1235
 msgid "No supported terminal found"
 msgstr "Nenhum terminal suportado encontrado"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1221 src/main.rs:1259 src/main.rs:1277 src/main.rs:1313
-#: src/main.rs:1492 src/main.rs:1514
+#: src/main.rs:1240 src/main.rs:1278 src/main.rs:1296 src/main.rs:1332
+#: src/main.rs:1511 src/main.rs:1533
 msgid "Ok"
 msgstr "Ok"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1234
+#: src/main.rs:1253
 msgid "No Boxes"
 msgstr "Sem Caixas"
 
 #. TRANSLATORS: Instructions
-#: src/main.rs:1237
+#: src/main.rs:1256
 msgid "Click the + at the top-left to create your first box!"
 msgstr ""
 "Pressione no + no canto superior esquerdo para criar sua primeira caixa!"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1249
+#: src/main.rs:1268
 msgid ""
 "You appear to be using a Flatpak of BoxBuddy without filesystem access. If "
 "you wish to set a Custom Home Directory you will need to grant filesystem "
@@ -312,12 +312,12 @@ msgstr ""
 "tips'> para mais detalhes. </a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1253
+#: src/main.rs:1272
 msgid "Sandboxed Flatpak Detected"
 msgstr "Flatpak em Sandbox Detectado"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1268
+#: src/main.rs:1287
 msgid ""
 "Distrobox can already access folders in your home directory - even if you "
 "have specified a custom home folder"
@@ -326,56 +326,56 @@ msgstr ""
 "você tenha especificado um diretório home customizado"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1272
+#: src/main.rs:1291
 msgid "Volume is already accessible"
 msgstr "Volume já está acessível"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1302
+#: src/main.rs:1321
 msgid "You don't appear to have any boxes which can install {} files"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1308
+#: src/main.rs:1327
 msgid "No Suitable Boxes Found"
 msgstr "Nenhuma caixa adequada encontrada"
 
 #. TRANSLATORS: Popup Window Title - {} replaced with .deb or .rpm
-#: src/main.rs:1322
+#: src/main.rs:1341
 msgid "Install {} File"
 msgstr "Instalar Arquivo {}"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1330
+#: src/main.rs:1349
 msgid "Install"
 msgstr "Instalar"
 
 #. TRANSLATORS: Info message - {} replaced with a file path
-#: src/main.rs:1354
+#: src/main.rs:1373
 msgid "Installing: {}"
 msgstr ""
 
-#: src/main.rs:1358
+#: src/main.rs:1377
 msgid "Select a box to install this file into:"
 msgstr "Selecionar caixa para instalar esse arquivo:"
 
 #. TRANSLATORS - Label for Dropdown of existing Boxes to install .deb or .rpm into
-#: src/main.rs:1376
+#: src/main.rs:1395
 msgid "Box"
 msgstr "Caixa"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1414
+#: src/main.rs:1433
 msgid "DEB Files"
 msgstr "Arquivos DEB"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1449
+#: src/main.rs:1468
 msgid "RPM Files"
 msgstr "Arquivos RPM"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1482
+#: src/main.rs:1501
 msgid ""
 "This file is not accessible to Flatpak - please copy it to your Downloads "
 "folder, or allow filesystem access. Please see the <a href='https://dvlv."
@@ -387,47 +387,47 @@ msgstr ""
 "tips'> para mais detalhes.</a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1486
+#: src/main.rs:1505
 msgid "File Not Accessible"
 msgstr "Arquivo Não Acessível"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1505
+#: src/main.rs:1524
 msgid "This file does not appear to be a {} file"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1509
+#: src/main.rs:1528
 msgid "Incorrect File Type"
 msgstr "Tipo de Arquivo Incorreto"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:1537
+#: src/main.rs:1556
 msgid "Preferred Terminal"
 msgstr "Terminal Preferido"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1545
+#: src/main.rs:1564
 msgid "Save"
 msgstr "Salvar"
 
 #. TRANSLATORS: Instructions label
-#: src/main.rs:1566
+#: src/main.rs:1585
 msgid "Select your preferred terminal"
 msgstr "Selecione seu terminal preferido"
 
 #. TRANSLATORS: Label for Dropdown of terminals available
-#: src/main.rs:1586
+#: src/main.rs:1605
 msgid "Terminal"
 msgstr "Terminal"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1606
+#: src/main.rs:1627
 msgid "Terminal Preference Saved!"
 msgstr "Preferência de Terminal Salva!"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1618
+#: src/main.rs:1638
 msgid "Sorry, Preference Could Not Be Saved"
 msgstr "Desculpe, Preferência Não Pode Ser Salva"
 

--- a/po/ru_RU/LC_MESSAGES/ru_RU.po
+++ b/po/ru_RU/LC_MESSAGES/ru_RU.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-13 08:56+0000\n"
+"POT-Creation-Date: 2024-06-14 07:12+0000\n"
 "PO-Revision-Date: 2024-06-13 10:59+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,168 +19,168 @@ msgstr ""
 "X-Generator: Poedit 3.4.4\n"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:139
+#: src/main.rs:150
 msgid "Create A Distrobox"
 msgstr "Создать Distrobox"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:158
+#: src/main.rs:169
 msgid "Assemble A Distrobox"
 msgstr "Собрать Distrobox"
 
 #. TRANSLATORS: File type
-#: src/main.rs:164
+#: src/main.rs:175
 msgid "INI-Files"
 msgstr "INI файлы"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:185
+#: src/main.rs:196
 msgid "Menu"
 msgstr "Меню"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:238
+#: src/main.rs:249
 msgid "Refresh"
 msgstr "Обновить"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:244
+#: src/main.rs:255
 msgid "Set Preferred Terminal"
 msgstr "Установить предпочтительный терминал"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:251
+#: src/main.rs:262
 msgid "About BoxBuddy"
 msgstr "Про BoxBuddy"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:256
+#: src/main.rs:267
 msgid "Quit"
 msgstr "Выйти"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:264
+#: src/main.rs:275
 msgid "Distrobox not found!"
 msgstr "Distrobox не найден!"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:269
+#: src/main.rs:280
 msgid "Distrobox could not be found, please ensure it is installed!"
 msgstr "Не удалось найти Distrobox - убедитесь, что эта программа установлена!"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:341
+#: src/main.rs:352
 msgid "Stop Box"
 msgstr "Остановить коробку"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:370
+#: src/main.rs:381
 msgid "Open Terminal"
 msgstr "Открыть терминал"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:383
+#: src/main.rs:394
 msgid "Upgrade Box"
 msgstr "Обновить коробку"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:395
+#: src/main.rs:406
 msgid "View Applications"
 msgstr "Посмотреть приложения"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:418
+#: src/main.rs:429
 msgid "Delete Box"
 msgstr "Удалить коробку"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:431
+#: src/main.rs:442
 msgid "Clone Box"
 msgstr "Клонировать коробку"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:451
+#: src/main.rs:462
 msgid "Install .deb File"
 msgstr "Установить .deb файл"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:463
+#: src/main.rs:474
 msgid "Install .rpm File"
 msgstr "Установить .rpm файл"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:512 src/main.rs:570
+#: src/main.rs:523 src/main.rs:581
 msgid "Create New Distrobox"
 msgstr "Создать новый Distrobox"
 
 #. TRANSLATORS: Context label of the application doing something
-#: src/main.rs:524
+#: src/main.rs:535
 msgid "Assembling Distroboxes, please wait..."
 msgstr "Собираем Distrobox-ы, пожалуйста подождите..."
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:578
+#: src/main.rs:589
 msgid "Create"
 msgstr "Создать"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:583
+#: src/main.rs:594
 msgid "Additional Information"
 msgstr "Дополнительная информация"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:588 src/main.rs:1059 src/main.rs:1104 src/main.rs:1334
-#: src/main.rs:1549
+#: src/main.rs:599 src/main.rs:1078 src/main.rs:1123 src/main.rs:1353
+#: src/main.rs:1568
 msgid "Cancel"
 msgstr "Отменить"
 
 #. TRANSLATORS: Entry Label - Name input for new distrobox
-#: src/main.rs:622 src/main.rs:1142
+#: src/main.rs:633 src/main.rs:1161
 msgid "Name"
 msgstr "Название"
 
 #. TRANSLATORS: Entry Label - Select home directory for new distrobox
-#: src/main.rs:643
+#: src/main.rs:654
 msgid "Home Directory (Leave blank for default)"
 msgstr "Домашняя папка (оставьте пустой для настроек по-умолчанию)"
 
 #. TRANSLATORS - Label for Dropdown where the user selects the container image to create
-#: src/main.rs:676
+#: src/main.rs:687
 msgid "Image"
 msgstr "Образ"
 
 #. TRANSLATORS - Label for Toggle when creating box to add systemd support
-#: src/main.rs:683
+#: src/main.rs:694
 msgid "Use init system"
 msgstr "Использовать систему инициализации"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:790
+#: src/main.rs:801
 msgid "Add a volume"
 msgstr "Дополнительные разделы"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:803
+#: src/main.rs:814
 msgid "Remove volume"
 msgstr ""
 
 #. TRANSLATORS: Help text for volume input
-#: src/main.rs:816
+#: src/main.rs:827
 msgid "Enter the location to mount this folder inside your new box"
 msgstr "Введите путь чтобы примонтировать эту папку внутри вашей новой коробки"
 
 #. TRANSLATORS: Subheading
-#: src/main.rs:840
+#: src/main.rs:851
 msgid "Additional Volumes:"
 msgstr "Дополнительные разделы:"
 
 #. TRANSLATORS: Context for the Additional Volumes subheading
-#: src/main.rs:843
+#: src/main.rs:854
 msgid "Additional directories the new box should be able to access"
 msgstr "Дополнительные папки к которым новая коробка должна иметь доступ"
 
 #. TRANSLATORS: Description of the application
-#: src/main.rs:867
+#: src/main.rs:878
 msgid ""
 "A Graphical Manager for your Distroboxes.\n"
 "    \n"
@@ -192,114 +192,114 @@ msgid ""
 msgstr ""
 
 #. TRANSLATORS: Window Title - shows list of installed applications in distrobox
-#: src/main.rs:893
+#: src/main.rs:912
 msgid "Installed Applications"
 msgstr "Установленные приложения"
 
 #. TRANSLATORS: Loading Message
-#: src/main.rs:911
+#: src/main.rs:930
 msgid "Loading..."
 msgstr "Загрузка..."
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:954
+#: src/main.rs:973
 msgid "No Applications Installed"
 msgstr "Нет установленых приложений"
 
 #. TRANSLATORS: Window Title
-#: src/main.rs:959
+#: src/main.rs:978
 msgid "Available Applications"
 msgstr "Доступные приложения"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:972
+#: src/main.rs:991
 msgid "Run"
 msgstr "Запустить"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:988
+#: src/main.rs:1007
 msgid "Remove From Menu"
 msgstr "Удалить из меню"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1005
+#: src/main.rs:1024
 msgid "Add To Menu"
 msgstr "Добавить в меню"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1036
+#: src/main.rs:1055
 msgid "App Exported!"
 msgstr "Приложение експортировано!"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1042
+#: src/main.rs:1061
 msgid "App Removed!"
 msgstr "Приложение удалено!"
 
 #. TRANSLATORS: Confirmation Dialogue
-#: src/main.rs:1053
+#: src/main.rs:1072
 msgid "Really Delete?"
 msgstr "Действительно удалить?"
 
 #. TRANSLATORS: Confirmation Dialogue - {} replaced with the name of the Distrobox
-#: src/main.rs:1055
+#: src/main.rs:1074
 msgid "Are you sure you want to delete {}?"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1061
+#: src/main.rs:1080
 msgid "Delete"
 msgstr "Удалить"
 
 #. TRANSLATORS: Success Text
-#: src/main.rs:1074
+#: src/main.rs:1093
 msgid "Box Deleted!"
 msgstr "Коробка удалена!"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1096 src/main.rs:1100
+#: src/main.rs:1115 src/main.rs:1119
 msgid "Clone"
 msgstr "Клонировать"
 
 #. TRANSLATORS: Title / Instruction label
-#: src/main.rs:1126
+#: src/main.rs:1145
 msgid "Enter the name of your new box"
 msgstr "Введите имя вашей новой коробки"
 
-#: src/main.rs:1130
+#: src/main.rs:1149
 msgid "Note: Cloning can take a long time, please be patient"
 msgstr ""
 "Примечание: Клонирование может занять много времени, пожалуйста, будьте "
 "терпеливы"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1211
+#: src/main.rs:1230
 msgid "Please install one of the supported terminals:"
 msgstr "Пожалуйста, установите один из поддерживаемых терминалов:"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1216
+#: src/main.rs:1235
 msgid "No supported terminal found"
 msgstr "Не найдено поддерживаемых терминалов"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1221 src/main.rs:1259 src/main.rs:1277 src/main.rs:1313
-#: src/main.rs:1492 src/main.rs:1514
+#: src/main.rs:1240 src/main.rs:1278 src/main.rs:1296 src/main.rs:1332
+#: src/main.rs:1511 src/main.rs:1533
 msgid "Ok"
 msgstr "Хорошо"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1234
+#: src/main.rs:1253
 msgid "No Boxes"
 msgstr "Нет коробок"
 
 #. TRANSLATORS: Instructions
-#: src/main.rs:1237
+#: src/main.rs:1256
 msgid "Click the + at the top-left to create your first box!"
 msgstr "Нажмите на + сверху-слева чтобы создать вашу первую коробку!"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1249
+#: src/main.rs:1268
 msgid ""
 "You appear to be using a Flatpak of BoxBuddy without filesystem access. If "
 "you wish to set a Custom Home Directory you will need to grant filesystem "
@@ -312,12 +312,12 @@ msgstr ""
 "href='https://dvlv.github.io/BoxBuddyRS/tips'>документации.</a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1253
+#: src/main.rs:1272
 msgid "Sandboxed Flatpak Detected"
 msgstr "Обнаружена песочница Flatpak"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1268
+#: src/main.rs:1287
 msgid ""
 "Distrobox can already access folders in your home directory - even if you "
 "have specified a custom home folder"
@@ -326,56 +326,56 @@ msgstr ""
 "выбрали собственную домашнюю папку"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1272
+#: src/main.rs:1291
 msgid "Volume is already accessible"
 msgstr "Раздел уже доступный"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1302
+#: src/main.rs:1321
 msgid "You don't appear to have any boxes which can install {} files"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1308
+#: src/main.rs:1327
 msgid "No Suitable Boxes Found"
 msgstr "Не найдено подходящих коробок"
 
 #. TRANSLATORS: Popup Window Title - {} replaced with .deb or .rpm
-#: src/main.rs:1322
+#: src/main.rs:1341
 msgid "Install {} File"
 msgstr "Установить {} файл"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1330
+#: src/main.rs:1349
 msgid "Install"
 msgstr "Установить"
 
 #. TRANSLATORS: Info message - {} replaced with a file path
-#: src/main.rs:1354
+#: src/main.rs:1373
 msgid "Installing: {}"
 msgstr ""
 
-#: src/main.rs:1358
+#: src/main.rs:1377
 msgid "Select a box to install this file into:"
 msgstr "Выберите коробку, в которую будет установлен этот файл:"
 
 #. TRANSLATORS - Label for Dropdown of existing Boxes to install .deb or .rpm into
-#: src/main.rs:1376
+#: src/main.rs:1395
 msgid "Box"
 msgstr "Коробка"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1414
+#: src/main.rs:1433
 msgid "DEB Files"
 msgstr "DEB файл"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1449
+#: src/main.rs:1468
 msgid "RPM Files"
 msgstr "RPM файл"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1482
+#: src/main.rs:1501
 msgid ""
 "This file is not accessible to Flatpak - please copy it to your Downloads "
 "folder, or allow filesystem access. Please see the <a href='https://dvlv."
@@ -386,46 +386,46 @@ msgstr ""
 "href='https://dvlv.github.io/BoxBuddyRS/tips'>документации.</a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1486
+#: src/main.rs:1505
 msgid "File Not Accessible"
 msgstr "Файл недоступен"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1505
+#: src/main.rs:1524
 msgid "This file does not appear to be a {} file"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1509
+#: src/main.rs:1528
 msgid "Incorrect File Type"
 msgstr "Неправильный тип файла"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:1537
+#: src/main.rs:1556
 msgid "Preferred Terminal"
 msgstr "Предпочтительный терминал"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1545
+#: src/main.rs:1564
 msgid "Save"
 msgstr "Сохранить"
 
 #. TRANSLATORS: Instructions label
-#: src/main.rs:1566
+#: src/main.rs:1585
 msgid "Select your preferred terminal"
 msgstr "Выберите предпочтительный терминал"
 
 #. TRANSLATORS: Label for Dropdown of terminals available
-#: src/main.rs:1586
+#: src/main.rs:1605
 msgid "Terminal"
 msgstr "Терминал"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1606
+#: src/main.rs:1627
 msgid "Terminal Preference Saved!"
 msgstr "Предпочтения терминала сохранены!"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1618
+#: src/main.rs:1638
 msgid "Sorry, Preference Could Not Be Saved"
 msgstr "Извините, настройки предпочтения не удалось сохранить"

--- a/po/uk_UA/LC_MESSAGES/uk_UA.po
+++ b/po/uk_UA/LC_MESSAGES/uk_UA.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-13 08:56+0000\n"
+"POT-Creation-Date: 2024-06-14 07:12+0000\n"
 "PO-Revision-Date: 2024-06-13 11:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -19,168 +19,168 @@ msgstr ""
 "X-Generator: Poedit 3.4.4\n"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:139
+#: src/main.rs:150
 msgid "Create A Distrobox"
 msgstr "Створити Distrobox"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:158
+#: src/main.rs:169
 msgid "Assemble A Distrobox"
 msgstr "Зібрати Distrobox"
 
 #. TRANSLATORS: File type
-#: src/main.rs:164
+#: src/main.rs:175
 msgid "INI-Files"
 msgstr "INI файли"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:185
+#: src/main.rs:196
 msgid "Menu"
 msgstr "Меню"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:238
+#: src/main.rs:249
 msgid "Refresh"
 msgstr "Оновити"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:244
+#: src/main.rs:255
 msgid "Set Preferred Terminal"
 msgstr "Встановити бажаний термінал"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:251
+#: src/main.rs:262
 msgid "About BoxBuddy"
 msgstr "Про BoxBuddy"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:256
+#: src/main.rs:267
 msgid "Quit"
 msgstr "Вийти"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:264
+#: src/main.rs:275
 msgid "Distrobox not found!"
 msgstr "Distrobox не знайдено!"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:269
+#: src/main.rs:280
 msgid "Distrobox could not be found, please ensure it is installed!"
 msgstr "Distrobox не знайдено, будь ласка, переконайтеся, що його встановлено!"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:341
+#: src/main.rs:352
 msgid "Stop Box"
 msgstr "Зупинити коробку"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:370
+#: src/main.rs:381
 msgid "Open Terminal"
 msgstr "Відкрити термінал"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:383
+#: src/main.rs:394
 msgid "Upgrade Box"
 msgstr "Оновити коробку"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:395
+#: src/main.rs:406
 msgid "View Applications"
 msgstr "Переглянути додатки"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:418
+#: src/main.rs:429
 msgid "Delete Box"
 msgstr "Видалити коробку"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:431
+#: src/main.rs:442
 msgid "Clone Box"
 msgstr "Клонувати коробку"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:451
+#: src/main.rs:462
 msgid "Install .deb File"
 msgstr "Встановити .deb файл"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:463
+#: src/main.rs:474
 msgid "Install .rpm File"
 msgstr "Встановити .rpm файл"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:512 src/main.rs:570
+#: src/main.rs:523 src/main.rs:581
 msgid "Create New Distrobox"
 msgstr "Створити новий Distrobox"
 
 #. TRANSLATORS: Context label of the application doing something
-#: src/main.rs:524
+#: src/main.rs:535
 msgid "Assembling Distroboxes, please wait..."
 msgstr "Збираємо Distrobox-и, будь ласка, зачекайте..."
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:578
+#: src/main.rs:589
 msgid "Create"
 msgstr "Створити"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:583
+#: src/main.rs:594
 msgid "Additional Information"
 msgstr "Додаткова інформація"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:588 src/main.rs:1059 src/main.rs:1104 src/main.rs:1334
-#: src/main.rs:1549
+#: src/main.rs:599 src/main.rs:1078 src/main.rs:1123 src/main.rs:1353
+#: src/main.rs:1568
 msgid "Cancel"
 msgstr "Скасувати"
 
 #. TRANSLATORS: Entry Label - Name input for new distrobox
-#: src/main.rs:622 src/main.rs:1142
+#: src/main.rs:633 src/main.rs:1161
 msgid "Name"
 msgstr "Назва"
 
 #. TRANSLATORS: Entry Label - Select home directory for new distrobox
-#: src/main.rs:643
+#: src/main.rs:654
 msgid "Home Directory (Leave blank for default)"
 msgstr "Домашній каталог (залиште порожнім за замовчуванням)"
 
 #. TRANSLATORS - Label for Dropdown where the user selects the container image to create
-#: src/main.rs:676
+#: src/main.rs:687
 msgid "Image"
 msgstr "Зображення"
 
 #. TRANSLATORS - Label for Toggle when creating box to add systemd support
-#: src/main.rs:683
+#: src/main.rs:694
 msgid "Use init system"
 msgstr "Використовувати систему ініціалізації"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:790
+#: src/main.rs:801
 msgid "Add a volume"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:803
+#: src/main.rs:814
 msgid "Remove volume"
 msgstr ""
 
 #. TRANSLATORS: Help text for volume input
-#: src/main.rs:816
+#: src/main.rs:827
 msgid "Enter the location to mount this folder inside your new box"
 msgstr "Вкажіть місце для монтування цієї теки у вашій новій коробці"
 
 #. TRANSLATORS: Subheading
-#: src/main.rs:840
+#: src/main.rs:851
 msgid "Additional Volumes:"
 msgstr "Додаткові розділи:"
 
 #. TRANSLATORS: Context for the Additional Volumes subheading
-#: src/main.rs:843
+#: src/main.rs:854
 msgid "Additional directories the new box should be able to access"
 msgstr "Додаткові каталоги, до яких нова коробка має мати доступ"
 
 #. TRANSLATORS: Description of the application
-#: src/main.rs:867
+#: src/main.rs:878
 msgid ""
 "A Graphical Manager for your Distroboxes.\n"
 "    \n"
@@ -192,114 +192,114 @@ msgid ""
 msgstr ""
 
 #. TRANSLATORS: Window Title - shows list of installed applications in distrobox
-#: src/main.rs:893
+#: src/main.rs:912
 msgid "Installed Applications"
 msgstr "Встановлені додатки"
 
 #. TRANSLATORS: Loading Message
-#: src/main.rs:911
+#: src/main.rs:930
 msgid "Loading..."
 msgstr "Завантаження..."
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:954
+#: src/main.rs:973
 msgid "No Applications Installed"
 msgstr "Немає встановлених додатків"
 
 #. TRANSLATORS: Window Title
-#: src/main.rs:959
+#: src/main.rs:978
 msgid "Available Applications"
 msgstr "Доступні додатки"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:972
+#: src/main.rs:991
 msgid "Run"
 msgstr "Виконати"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:988
+#: src/main.rs:1007
 msgid "Remove From Menu"
 msgstr "Видалити з меню"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1005
+#: src/main.rs:1024
 msgid "Add To Menu"
 msgstr "Додати до меню"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1036
+#: src/main.rs:1055
 msgid "App Exported!"
 msgstr "Додаток експортована!"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1042
+#: src/main.rs:1061
 msgid "App Removed!"
 msgstr "Додаток видалено!"
 
 #. TRANSLATORS: Confirmation Dialogue
-#: src/main.rs:1053
+#: src/main.rs:1072
 msgid "Really Delete?"
 msgstr "Справді видалити?"
 
 #. TRANSLATORS: Confirmation Dialogue - {} replaced with the name of the Distrobox
-#: src/main.rs:1055
+#: src/main.rs:1074
 msgid "Are you sure you want to delete {}?"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1061
+#: src/main.rs:1080
 msgid "Delete"
 msgstr "Видалити"
 
 #. TRANSLATORS: Success Text
-#: src/main.rs:1074
+#: src/main.rs:1093
 msgid "Box Deleted!"
 msgstr "Коробка видалена!"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1096 src/main.rs:1100
+#: src/main.rs:1115 src/main.rs:1119
 msgid "Clone"
 msgstr "Клонувати"
 
 #. TRANSLATORS: Title / Instruction label
-#: src/main.rs:1126
+#: src/main.rs:1145
 msgid "Enter the name of your new box"
 msgstr "Введіть ім'я вашої нової коробки"
 
-#: src/main.rs:1130
+#: src/main.rs:1149
 msgid "Note: Cloning can take a long time, please be patient"
 msgstr ""
 "Примітка: Клонування може зайняти багато часу, будь ласка, наберіться "
 "терпіння"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1211
+#: src/main.rs:1230
 msgid "Please install one of the supported terminals:"
 msgstr "Будь ласка, встановіть один з підтримуваних терміналів:"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1216
+#: src/main.rs:1235
 msgid "No supported terminal found"
 msgstr "Не знайдено підтримуваного терміналу"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1221 src/main.rs:1259 src/main.rs:1277 src/main.rs:1313
-#: src/main.rs:1492 src/main.rs:1514
+#: src/main.rs:1240 src/main.rs:1278 src/main.rs:1296 src/main.rs:1332
+#: src/main.rs:1511 src/main.rs:1533
 msgid "Ok"
 msgstr "Ок"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1234
+#: src/main.rs:1253
 msgid "No Boxes"
 msgstr "Немає коробок"
 
 #. TRANSLATORS: Instructions
-#: src/main.rs:1237
+#: src/main.rs:1256
 msgid "Click the + at the top-left to create your first box!"
 msgstr "Клацніть на + зверху-зліва щоб створити вашу першу коробку!"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1249
+#: src/main.rs:1268
 msgid ""
 "You appear to be using a Flatpak of BoxBuddy without filesystem access. If "
 "you wish to set a Custom Home Directory you will need to grant filesystem "
@@ -313,12 +313,12 @@ msgstr ""
 "a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1253
+#: src/main.rs:1272
 msgid "Sandboxed Flatpak Detected"
 msgstr "Виявлено пісочницю Flatpak"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1268
+#: src/main.rs:1287
 msgid ""
 "Distrobox can already access folders in your home directory - even if you "
 "have specified a custom home folder"
@@ -327,56 +327,56 @@ msgstr ""
 "ви вказали власний домашній каталог"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1272
+#: src/main.rs:1291
 msgid "Volume is already accessible"
 msgstr "Розділ вже доступний"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1302
+#: src/main.rs:1321
 msgid "You don't appear to have any boxes which can install {} files"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1308
+#: src/main.rs:1327
 msgid "No Suitable Boxes Found"
 msgstr "Відповідних коробок не знайдено"
 
 #. TRANSLATORS: Popup Window Title - {} replaced with .deb or .rpm
-#: src/main.rs:1322
+#: src/main.rs:1341
 msgid "Install {} File"
 msgstr "Встановити {} файл"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1330
+#: src/main.rs:1349
 msgid "Install"
 msgstr "Встановити"
 
 #. TRANSLATORS: Info message - {} replaced with a file path
-#: src/main.rs:1354
+#: src/main.rs:1373
 msgid "Installing: {}"
 msgstr ""
 
-#: src/main.rs:1358
+#: src/main.rs:1377
 msgid "Select a box to install this file into:"
 msgstr "Виберіть коробку, до якої ви хочете встановити цей файл:"
 
 #. TRANSLATORS - Label for Dropdown of existing Boxes to install .deb or .rpm into
-#: src/main.rs:1376
+#: src/main.rs:1395
 msgid "Box"
 msgstr "Коробка"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1414
+#: src/main.rs:1433
 msgid "DEB Files"
 msgstr "DEB файл"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1449
+#: src/main.rs:1468
 msgid "RPM Files"
 msgstr "RPM файл"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1482
+#: src/main.rs:1501
 msgid ""
 "This file is not accessible to Flatpak - please copy it to your Downloads "
 "folder, or allow filesystem access. Please see the <a href='https://dvlv."
@@ -388,46 +388,46 @@ msgstr ""
 "детальної інформації.</a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1486
+#: src/main.rs:1505
 msgid "File Not Accessible"
 msgstr "Файл недоступний"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1505
+#: src/main.rs:1524
 msgid "This file does not appear to be a {} file"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1509
+#: src/main.rs:1528
 msgid "Incorrect File Type"
 msgstr "Неправильний тип файлу"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:1537
+#: src/main.rs:1556
 msgid "Preferred Terminal"
 msgstr "Обраний термінал"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1545
+#: src/main.rs:1564
 msgid "Save"
 msgstr "Зберегти"
 
 #. TRANSLATORS: Instructions label
-#: src/main.rs:1566
+#: src/main.rs:1585
 msgid "Select your preferred terminal"
 msgstr "Виберіть бажаний термінал"
 
 #. TRANSLATORS: Label for Dropdown of terminals available
-#: src/main.rs:1586
+#: src/main.rs:1605
 msgid "Terminal"
 msgstr "Термінал"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1606
+#: src/main.rs:1627
 msgid "Terminal Preference Saved!"
 msgstr "Налаштування терміналу збережено!"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1618
+#: src/main.rs:1638
 msgid "Sorry, Preference Could Not Be Saved"
 msgstr "Вибачте, налаштування не вдалося зберегти"

--- a/po/zh_CN/LC_MESSAGES/zh_CN.po
+++ b/po/zh_CN/LC_MESSAGES/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 2.2.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-13 08:56+0000\n"
+"POT-Creation-Date: 2024-06-14 07:12+0000\n"
 "PO-Revision-Date: 2024-06-13 11:00+0200\n"
 "Last-Translator: MLSci <mi6w.io@gmail.com>\n"
 "Language-Team: \n"
@@ -19,168 +19,168 @@ msgstr ""
 "X-Generator: Poedit 3.4.4\n"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:139
+#: src/main.rs:150
 msgid "Create A Distrobox"
 msgstr "创建一个 Distrobox"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:158
+#: src/main.rs:169
 msgid "Assemble A Distrobox"
 msgstr "组装一个 Distrobox"
 
 #. TRANSLATORS: File type
-#: src/main.rs:164
+#: src/main.rs:175
 msgid "INI-Files"
 msgstr "INI 文件"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:185
+#: src/main.rs:196
 msgid "Menu"
 msgstr "菜单"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:238
+#: src/main.rs:249
 msgid "Refresh"
 msgstr "刷新"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:244
+#: src/main.rs:255
 msgid "Set Preferred Terminal"
 msgstr "设置首选终端"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:251
+#: src/main.rs:262
 msgid "About BoxBuddy"
 msgstr "关于 BoxBuddy"
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:256
+#: src/main.rs:267
 msgid "Quit"
 msgstr "退出"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:264
+#: src/main.rs:275
 msgid "Distrobox not found!"
 msgstr "未找到 Distrobox！"
 
 #. TRANSLATORS: Error message
-#: src/main.rs:269
+#: src/main.rs:280
 msgid "Distrobox could not be found, please ensure it is installed!"
 msgstr "无法找到Distrobox，请确保其已安装！"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:341
+#: src/main.rs:352
 msgid "Stop Box"
 msgstr "停止盒子"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:370
+#: src/main.rs:381
 msgid "Open Terminal"
 msgstr "打开终端"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:383
+#: src/main.rs:394
 msgid "Upgrade Box"
 msgstr "升级盒子"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:395
+#: src/main.rs:406
 msgid "View Applications"
 msgstr "查看应用程序"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:418
+#: src/main.rs:429
 msgid "Delete Box"
 msgstr "删除盒子"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:431
+#: src/main.rs:442
 msgid "Clone Box"
 msgstr "克隆盒子"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:451
+#: src/main.rs:462
 msgid "Install .deb File"
 msgstr "安装 .deb 文件"
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:463
+#: src/main.rs:474
 msgid "Install .rpm File"
 msgstr "安装 .rpm 文件"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:512 src/main.rs:570
+#: src/main.rs:523 src/main.rs:581
 msgid "Create New Distrobox"
 msgstr "创建新的 Distrobox"
 
 #. TRANSLATORS: Context label of the application doing something
-#: src/main.rs:524
+#: src/main.rs:535
 msgid "Assembling Distroboxes, please wait..."
 msgstr "正在组装 Distrobox，请稍候..."
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:578
+#: src/main.rs:589
 msgid "Create"
 msgstr "创建"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:583
+#: src/main.rs:594
 msgid "Additional Information"
 msgstr "附加信息"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:588 src/main.rs:1059 src/main.rs:1104 src/main.rs:1334
-#: src/main.rs:1549
+#: src/main.rs:599 src/main.rs:1078 src/main.rs:1123 src/main.rs:1353
+#: src/main.rs:1568
 msgid "Cancel"
 msgstr "取消"
 
 #. TRANSLATORS: Entry Label - Name input for new distrobox
-#: src/main.rs:622 src/main.rs:1142
+#: src/main.rs:633 src/main.rs:1161
 msgid "Name"
 msgstr "名称"
 
 #. TRANSLATORS: Entry Label - Select home directory for new distrobox
-#: src/main.rs:643
+#: src/main.rs:654
 msgid "Home Directory (Leave blank for default)"
 msgstr "主目录（默认留空）"
 
 #. TRANSLATORS - Label for Dropdown where the user selects the container image to create
-#: src/main.rs:676
+#: src/main.rs:687
 msgid "Image"
 msgstr "镜像"
 
 #. TRANSLATORS - Label for Toggle when creating box to add systemd support
-#: src/main.rs:683
+#: src/main.rs:694
 msgid "Use init system"
 msgstr "使用初始化系统"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:790
+#: src/main.rs:801
 msgid "Add a volume"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:803
+#: src/main.rs:814
 msgid "Remove volume"
 msgstr ""
 
 #. TRANSLATORS: Help text for volume input
-#: src/main.rs:816
+#: src/main.rs:827
 msgid "Enter the location to mount this folder inside your new box"
 msgstr "输入在新盒子中挂载此文件夹的位置"
 
 #. TRANSLATORS: Subheading
-#: src/main.rs:840
+#: src/main.rs:851
 msgid "Additional Volumes:"
 msgstr "附加卷："
 
 #. TRANSLATORS: Context for the Additional Volumes subheading
-#: src/main.rs:843
+#: src/main.rs:854
 msgid "Additional directories the new box should be able to access"
 msgstr "新盒子应该能够访问的其他目录"
 
 #. TRANSLATORS: Description of the application
-#: src/main.rs:867
+#: src/main.rs:878
 msgid ""
 "A Graphical Manager for your Distroboxes.\n"
 "    \n"
@@ -192,129 +192,129 @@ msgid ""
 msgstr ""
 
 #. TRANSLATORS: Window Title - shows list of installed applications in distrobox
-#: src/main.rs:893
+#: src/main.rs:912
 msgid "Installed Applications"
 msgstr "已安装的应用程序"
 
 #. TRANSLATORS: Loading Message
-#: src/main.rs:911
+#: src/main.rs:930
 msgid "Loading..."
 msgstr "正在加载..."
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:954
+#: src/main.rs:973
 msgid "No Applications Installed"
 msgstr "未安装任何应用程序"
 
 #. TRANSLATORS: Window Title
-#: src/main.rs:959
+#: src/main.rs:978
 msgid "Available Applications"
 msgstr "可用的应用程序"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:972
+#: src/main.rs:991
 msgid "Run"
 msgstr "运行"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:988
+#: src/main.rs:1007
 msgid "Remove From Menu"
 msgstr "从菜单中删除"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1005
+#: src/main.rs:1024
 msgid "Add To Menu"
 msgstr "添加到菜单"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1036
+#: src/main.rs:1055
 msgid "App Exported!"
 msgstr "应用程序已导出！"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1042
+#: src/main.rs:1061
 msgid "App Removed!"
 msgstr "应用程序已删除！"
 
 #. TRANSLATORS: Confirmation Dialogue
-#: src/main.rs:1053
+#: src/main.rs:1072
 msgid "Really Delete?"
 msgstr "真的删除吗？"
 
 #. TRANSLATORS: Confirmation Dialogue - {} replaced with the name of the Distrobox
-#: src/main.rs:1055
+#: src/main.rs:1074
 msgid "Are you sure you want to delete {}?"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1061
+#: src/main.rs:1080
 msgid "Delete"
 msgstr "删除"
 
 #. TRANSLATORS: Success Text
-#: src/main.rs:1074
+#: src/main.rs:1093
 msgid "Box Deleted!"
 msgstr "盒子已删除！"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1096 src/main.rs:1100
+#: src/main.rs:1115 src/main.rs:1119
 msgid "Clone"
 msgstr "克隆"
 
 #. TRANSLATORS: Title / Instruction label
-#: src/main.rs:1126
+#: src/main.rs:1145
 msgid "Enter the name of your new box"
 msgstr "输入新盒子的名称"
 
-#: src/main.rs:1130
+#: src/main.rs:1149
 msgid "Note: Cloning can take a long time, please be patient"
 msgstr "注意：克隆可能需要很长时间，请耐心等待"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1211
+#: src/main.rs:1230
 msgid "Please install one of the supported terminals:"
 msgstr "请安装支持的终端之一："
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1216
+#: src/main.rs:1235
 msgid "No supported terminal found"
 msgstr "未找到支持的终端"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1221 src/main.rs:1259 src/main.rs:1277 src/main.rs:1313
-#: src/main.rs:1492 src/main.rs:1514
+#: src/main.rs:1240 src/main.rs:1278 src/main.rs:1296 src/main.rs:1332
+#: src/main.rs:1511 src/main.rs:1533
 msgid "Ok"
 msgstr "好的"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1234
+#: src/main.rs:1253
 msgid "No Boxes"
 msgstr "没有盒子"
 
 #. TRANSLATORS: Instructions
-#: src/main.rs:1237
+#: src/main.rs:1256
 msgid "Click the + at the top-left to create your first box!"
 msgstr "点击左上角的+来创建你的第一个盒子！"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1249
+#: src/main.rs:1268
 msgid ""
 "You appear to be using a Flatpak of BoxBuddy without filesystem access. If "
 "you wish to set a Custom Home Directory you will need to grant filesystem "
 "access. Please see the <a href='https://dvlv.github.io/BoxBuddyRS/"
 "tips'>documentation for details.</a>"
 msgstr ""
-"您似乎正在使用 BoxBuddy 的 Flatpak，但没有文件系统访问权限。如果您希望设置"
-"自定义主目录，则需要授予文件系统访问权限。请参阅 <a href='https://dvlv."
-"github.io/ BoxBuddyRS/tips'>有关详细信息的文档。</a>"
+"您似乎正在使用 BoxBuddy 的 Flatpak，但没有文件系统访问权限。如果您希望设置自"
+"定义主目录，则需要授予文件系统访问权限。请参阅 <a href='https://dvlv.github."
+"io/ BoxBuddyRS/tips'>有关详细信息的文档。</a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1253
+#: src/main.rs:1272
 msgid "Sandboxed Flatpak Detected"
 msgstr "检测到沙盒 Flatpak"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1268
+#: src/main.rs:1287
 msgid ""
 "Distrobox can already access folders in your home directory - even if you "
 "have specified a custom home folder"
@@ -322,105 +322,105 @@ msgstr ""
 "Distrobox 已经可以访问您主目录中的文件夹 - 即使您已经指定了自定义主文件夹"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1272
+#: src/main.rs:1291
 msgid "Volume is already accessible"
 msgstr "卷已经可以访问"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1302
+#: src/main.rs:1321
 msgid "You don't appear to have any boxes which can install {} files"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1308
+#: src/main.rs:1327
 msgid "No Suitable Boxes Found"
 msgstr "没有找到合适的盒子"
 
 #. TRANSLATORS: Popup Window Title - {} replaced with .deb or .rpm
-#: src/main.rs:1322
+#: src/main.rs:1341
 msgid "Install {} File"
 msgstr "安装 {} 文件"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1330
+#: src/main.rs:1349
 msgid "Install"
 msgstr "安装"
 
 #. TRANSLATORS: Info message - {} replaced with a file path
-#: src/main.rs:1354
+#: src/main.rs:1373
 msgid "Installing: {}"
 msgstr ""
 
-#: src/main.rs:1358
+#: src/main.rs:1377
 msgid "Select a box to install this file into:"
 msgstr "选择一个盒子来安装此文件："
 
 #. TRANSLATORS - Label for Dropdown of existing Boxes to install .deb or .rpm into
-#: src/main.rs:1376
+#: src/main.rs:1395
 msgid "Box"
 msgstr "盒子"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1414
+#: src/main.rs:1433
 msgid "DEB Files"
 msgstr "DEB 文件"
 
 #. TRANSLATORS: File type
-#: src/main.rs:1449
+#: src/main.rs:1468
 msgid "RPM Files"
 msgstr "RPM 文件"
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1482
+#: src/main.rs:1501
 msgid ""
 "This file is not accessible to Flatpak - please copy it to your Downloads "
 "folder, or allow filesystem access. Please see the <a href='https://dvlv."
 "github.io/BoxBuddyRS/tips'>documentation for details.</a>"
 msgstr ""
-"Flatpak 无法访问此文件 - 请将其复制到您的下载文件夹，或允许文件系统访问。请"
-"参阅<a href='https://dvlv.github.io/BoxBuddyRS/tips'>文档了解详细信息。</a>"
+"Flatpak 无法访问此文件 - 请将其复制到您的下载文件夹，或允许文件系统访问。请参"
+"阅<a href='https://dvlv.github.io/BoxBuddyRS/tips'>文档了解详细信息。</a>"
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1486
+#: src/main.rs:1505
 msgid "File Not Accessible"
 msgstr "文件不可访问"
 
 #. TRANSLATORS: Error / Info Message - {} replaced with .deb or .rpm
-#: src/main.rs:1505
+#: src/main.rs:1524
 msgid "This file does not appear to be a {} file"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1509
+#: src/main.rs:1528
 msgid "Incorrect File Type"
 msgstr "文件类型不正确"
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:1537
+#: src/main.rs:1556
 msgid "Preferred Terminal"
 msgstr "首选终端"
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1545
+#: src/main.rs:1564
 msgid "Save"
 msgstr "保存"
 
 #. TRANSLATORS: Instructions label
-#: src/main.rs:1566
+#: src/main.rs:1585
 msgid "Select your preferred terminal"
 msgstr "选择您首选的终端"
 
 #. TRANSLATORS: Label for Dropdown of terminals available
-#: src/main.rs:1586
+#: src/main.rs:1605
 msgid "Terminal"
 msgstr "终端"
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1606
+#: src/main.rs:1627
 msgid "Terminal Preference Saved!"
 msgstr "终端首选项已保存！"
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1618
+#: src/main.rs:1638
 msgid "Sorry, Preference Could Not Be Saved"
 msgstr "抱歉，无法保存首选项"

--- a/scripts/update-translations.sh
+++ b/scripts/update-translations.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+for dir in $(find po -type d)
+do
+  if [ -d "$dir/LC_MESSAGES" ]; then
+    fname="$(basename "$dir")";
+    (
+      set -x
+      msgmerge \
+        --verbose \
+        --no-fuzzy-matching \
+        --backup=none \
+        --update \
+        "$dir/LC_MESSAGES/$fname.po" "po/boxbuddy.pot"
+    )
+  fi
+done

--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -55,13 +55,13 @@ pub fn get_all_distroboxes() -> Vec<DBox> {
 
     let output = get_command_output(String::from("distrobox"), Some(&["list", "--no-color"]));
 
-    let headings: Vec<&str> = output
+    let headings = output
         .split('\n')
         .next()
         .unwrap()
         .split('|')
         .map(str::trim)
-        .collect();
+        .collect::<Vec<&str>>();
     //println!("headings: {:?}", headings);
 
     let mut heading_indexes = ColsIndexes {

--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -191,7 +191,14 @@ pub fn open_terminal_in_box(box_name: String) {
 pub fn export_app_from_box(app_name: &str, box_name: &str) -> String {
     get_command_output(
         "distrobox",
-        Some(&["enter", box_name, "--", "distrobox-export", "-a", app_name]),
+        Some(&[
+            "enter",
+            box_name,
+            "--",
+            "distrobox-export",
+            "--app",
+            app_name,
+        ]),
     )
 }
 
@@ -204,9 +211,9 @@ pub fn remove_app_from_host(app_name: &str, box_name: &str) -> String {
             box_name,
             "--",
             "distrobox-export",
-            "-a",
+            "--app",
             app_name,
-            "-d",
+            "--delete",
         ]),
     )
 }
@@ -255,7 +262,7 @@ pub fn upgrade_box(box_name: &str) {
 }
 
 pub fn delete_box(box_name: &str) -> String {
-    get_command_output("distrobox", Some(&["rm", box_name, "-f"]))
+    get_command_output("distrobox", Some(&["rm", box_name, "--force"]))
 }
 
 /// Creates a new distrobox, spawns a terminal with `distrobox enter` afterwards
@@ -302,7 +309,7 @@ pub fn assemble_box(ini_file: &str) -> String {
 /// Appends a little diamond if the image is already downloaded.
 pub fn get_available_images_with_distro_name() -> Vec<String> {
     let existing_images = get_repository_list();
-    let output = get_command_output("distrobox", Some(&["create", "-C"]));
+    let output = get_command_output("distrobox", Some(&["create", "--compatibility"]));
 
     let mut imgs: Vec<String> = Vec::new();
 
@@ -345,7 +352,7 @@ pub fn get_apps_in_box(box_name: &str) -> Vec<DBoxApp> {
             "--",
             "bash",
             "-c",
-            "grep -L \"NoDisplay=true\" /usr/share/applications/*.desktop",
+            "grep --files-without-match \"NoDisplay=true\" /usr/share/applications/*.desktop",
         ]),
     );
 
@@ -401,7 +408,7 @@ pub fn get_apps_in_box(box_name: &str) -> Vec<DBoxApp> {
 }
 
 pub fn stop_box(box_name: &str) {
-    let _ = run_command("distrobox", Some(&["stop", box_name, "-Y"]));
+    let _ = run_command("distrobox", Some(&["stop", box_name, "--yes"]));
 }
 
 /// Gets count of boxes, used to move the active page on the Notebook to the newest

--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -300,8 +300,8 @@ pub fn create_box(
 
 /// Runs `distrobox-assemble` with the provided file.
 pub fn assemble_box(ini_file: &str) -> String {
-    let args = vec!["assemble", "create", "--file", ini_file];
-    get_command_output("distrobox", Some(args.as_slice()))
+    let args = &["assemble", "create", "--file", ini_file];
+    get_command_output("distrobox", Some(args))
 }
 
 /// Grabs the list of available images via `distrobox create -C`.

--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -53,7 +53,7 @@ pub struct ColsIndexes {
 pub fn get_all_distroboxes() -> Vec<DBox> {
     let mut my_boxes: Vec<DBox> = vec![];
 
-    let output = get_command_output(String::from("distrobox"), Some(&["list", "--no-color"]));
+    let output = get_command_output("distrobox", Some(&["list", "--no-color"]));
 
     let headings = output
         .split('\n')
@@ -188,46 +188,39 @@ pub fn open_terminal_in_box(box_name: String) {
 }
 
 /// Exports the desktop file from a box.
-pub fn export_app_from_box(app_name: String, box_name: String) -> String {
+pub fn export_app_from_box(app_name: &str, box_name: &str) -> String {
     get_command_output(
-        String::from("distrobox"),
-        Some(&[
-            "enter",
-            &box_name,
-            "--",
-            "distrobox-export",
-            "-a",
-            &app_name,
-        ]),
+        "distrobox",
+        Some(&["enter", box_name, "--", "distrobox-export", "-a", app_name]),
     )
 }
 
 /// Unexports a desktop file from the host.
-pub fn remove_app_from_host(app_name: String, box_name: String) -> String {
+pub fn remove_app_from_host(app_name: &str, box_name: &str) -> String {
     get_command_output(
-        String::from("distrobox"),
+        "distrobox",
         Some(&[
             "enter",
-            &box_name,
+            box_name,
             "--",
             "distrobox-export",
             "-a",
-            &app_name,
+            app_name,
             "-d",
         ]),
     )
 }
 
 /// Runs a command inside a box using `distrobox enter --`. Does NOT spawn terminal.
-pub fn run_command_in_box(command: String, box_name: String) {
+pub fn run_command_in_box(command: &str, box_name: &str) {
     if is_flatpak() {
         Command::new(String::from("flatpak-spawn"))
-            .args(["--host", "distrobox", "enter", &box_name, "--", &command])
+            .args(["--host", "distrobox", "enter", box_name, "--", command])
             .spawn()
             .unwrap();
     } else {
         Command::new(String::from("distrobox"))
-            .args(["enter", &box_name, "--", &command])
+            .args(["enter", box_name, "--", command])
             .spawn()
             .unwrap();
     }
@@ -236,7 +229,7 @@ pub fn run_command_in_box(command: String, box_name: String) {
 /// Performs `distrobox upgrade` inside a box.
 /// Spawns a terminal, and runs `distrobox enter` afterwards just so the terminal
 /// stays open.
-pub fn upgrade_box(box_name: String) {
+pub fn upgrade_box(box_name: &str) {
     let (term, sep) = get_terminal_and_separator_arg();
     let command = format!("distrobox upgrade {box_name}; distrobox enter {box_name}");
 
@@ -261,20 +254,20 @@ pub fn upgrade_box(box_name: String) {
     }
 }
 
-pub fn delete_box(box_name: String) -> String {
-    get_command_output(String::from("distrobox"), Some(&["rm", &box_name, "-f"]))
+pub fn delete_box(box_name: &str) -> String {
+    get_command_output("distrobox", Some(&["rm", box_name, "-f"]))
 }
 
 /// Creates a new distrobox, spawns a terminal with `distrobox enter` afterwards
 /// to initialise it.
 pub fn create_box(
-    box_name: String,
-    image: String,
-    home_path: String,
+    box_name: &str,
+    image: &str,
+    home_path: &str,
     use_init: bool,
-    volumes: Vec<String>,
+    volumes: &[String],
 ) -> String {
-    let mut args = vec!["create", "-n", &box_name, "-i", &image, "-Y"];
+    let mut args = vec!["create", "-n", box_name, "-i", image, "-Y"];
     if is_nvidia() {
         args.push("--nvidia");
     }
@@ -285,23 +278,23 @@ pub fn create_box(
 
     if !home_path.is_empty() {
         args.push("--home");
-        args.push(&home_path);
+        args.push(home_path);
     }
 
     if !volumes.is_empty() {
-        for vol in &volumes {
+        for vol in volumes {
             args.push("--volume");
-            args.push(vol.as_str());
+            args.push(vol);
         }
     }
 
-    get_command_output(String::from("distrobox"), Some(args.as_slice()))
+    get_command_output("distrobox", Some(args.as_slice()))
 }
 
 /// Runs `distrobox-assemble` with the provided file.
-pub fn assemble_box(ini_file: String) -> String {
-    let args = vec!["assemble", "create", "--file", &ini_file];
-    get_command_output(String::from("distrobox"), Some(args.as_slice()))
+pub fn assemble_box(ini_file: &str) -> String {
+    let args = vec!["assemble", "create", "--file", ini_file];
+    get_command_output("distrobox", Some(args.as_slice()))
 }
 
 /// Grabs the list of available images via `distrobox create -C`.
@@ -309,7 +302,7 @@ pub fn assemble_box(ini_file: String) -> String {
 /// Appends a little diamond if the image is already downloaded.
 pub fn get_available_images_with_distro_name() -> Vec<String> {
     let existing_images = get_repository_list();
-    let output = get_command_output(String::from("distrobox"), Some(&["create", "-C"]));
+    let output = get_command_output("distrobox", Some(&["create", "-C"]));
 
     let mut imgs: Vec<String> = Vec::new();
 
@@ -338,17 +331,17 @@ pub fn get_available_images_with_distro_name() -> Vec<String> {
 }
 
 /// Lists desktop files available in a distrobox, for the View Applications pop-up
-pub fn get_apps_in_box(box_name: String) -> Vec<DBoxApp> {
+pub fn get_apps_in_box(box_name: &str) -> Vec<DBoxApp> {
     let mut apps: Vec<DBoxApp> = Vec::new();
 
     // get list of host apps to check against afterwards
     let host_apps = get_host_desktop_files();
 
     let desktop_files = get_command_output(
-        String::from("distrobox"),
+        "distrobox",
         Some(&[
             "enter",
-            &box_name,
+            box_name,
             "--",
             "bash",
             "-c",
@@ -361,10 +354,8 @@ pub fn get_apps_in_box(box_name: String) -> Vec<DBoxApp> {
             continue;
         }
 
-        let desktop_file_contents = get_command_output(
-            String::from("distrobox"),
-            Some(&["enter", &box_name, "--", "cat", line]),
-        );
+        let desktop_file_contents =
+            get_command_output("distrobox", Some(&["enter", box_name, "--", "cat", line]));
 
         let mut pieces: [String; 3] = [String::new(), String::new(), String::new()];
 
@@ -409,14 +400,14 @@ pub fn get_apps_in_box(box_name: String) -> Vec<DBoxApp> {
     apps
 }
 
-pub fn stop_box(box_name: String) {
-    let _ = run_command(String::from("distrobox"), Some(&["stop", &box_name, "-Y"]));
+pub fn stop_box(box_name: &str) {
+    let _ = run_command("distrobox", Some(&["stop", box_name, "-Y"]));
 }
 
 /// Gets count of boxes, used to move the active page on the Notebook to the newest
 /// box after creation.
 pub fn get_number_of_boxes() -> u32 {
-    let output = get_command_output(String::from("distrobox"), Some(&["list", "--no-color"]));
+    let output = get_command_output("distrobox", Some(&["list", "--no-color"]));
 
     // I would like to just do output.lines().count() but I get inconsistent results
     let mut count = 0;
@@ -512,11 +503,11 @@ pub fn install_rpm_in_box(box_name: String, file_path: String) {
     }
 }
 
-pub fn clone_box(box_to_clone: String, new_name: String) -> String {
-    stop_box(box_to_clone.clone());
+pub fn clone_box(box_to_clone: &str, new_name: &str) -> String {
+    stop_box(box_to_clone);
 
     get_command_output(
-        String::from("distrobox"),
-        Some(&["create", "--clone", &box_to_clone, "--name", &new_name]),
+        "distrobox",
+        Some(&["create", "--clone", box_to_clone, "--name", new_name]),
     )
 }

--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -55,13 +55,13 @@ pub fn get_all_distroboxes() -> Vec<DBox> {
 
     let output = get_command_output(String::from("distrobox"), Some(&["list", "--no-color"]));
 
-    let headings = output
+    let headings: Vec<&str> = output
         .split('\n')
         .next()
         .unwrap()
         .split('|')
-        .map(|h| h.trim())
-        .collect::<Vec<&str>>();
+        .map(str::trim)
+        .collect();
     //println!("headings: {:?}", headings);
 
     let mut heading_indexes = ColsIndexes {
@@ -86,7 +86,7 @@ pub fn get_all_distroboxes() -> Vec<DBox> {
             continue;
         }
 
-        let box_line = line.split('|').map(|l| l.trim()).collect::<Vec<&str>>();
+        let box_line = line.split('|').map(str::trim).collect::<Vec<&str>>();
         if box_line.len() > 3 {
             let status = String::from(box_line[heading_indexes.status]);
             let is_running = !status.contains("Exited") && !status.contains("Created");
@@ -289,7 +289,7 @@ pub fn create_box(
     }
 
     if !volumes.is_empty() {
-        for vol in volumes.iter() {
+        for vol in &volumes {
             args.push("--volume");
             args.push(vol.as_str());
         }
@@ -319,10 +319,10 @@ pub fn get_available_images_with_distro_name() -> Vec<String> {
         }
 
         let distro = try_parse_distro_name_from_url(line);
-        let mut pretty_line = if distro != "zunknown" {
-            format!("{} - {}", distro, line)
+        let mut pretty_line = if distro == "zunknown" {
+            format!("unknown - {line}")
         } else {
-            format!("unknown - {}", line)
+            format!("{distro} - {line}")
         };
 
         if existing_images.contains(&line.to_string()) {
@@ -366,7 +366,7 @@ pub fn get_apps_in_box(box_name: String) -> Vec<DBoxApp> {
             Some(&["enter", &box_name, "--", "cat", line]),
         );
 
-        let mut pieces: [String; 3] = [String::from(""), String::from(""), String::from("")];
+        let mut pieces: [String; 3] = [String::new(), String::new(), String::new()];
 
         for df_line in desktop_file_contents.split('\n') {
             if pieces[0].is_empty() && df_line.starts_with("Name=") {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 use adw::StyleManager;
-use gettextrs::*;
+use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use gtk::gio::Settings;
 use gtk::prelude::SettingsExt;
 use std::collections::HashMap;
@@ -11,7 +11,7 @@ use crate::get_all_distroboxes;
 use crate::APP_ID;
 
 /// Used to represent any Filesystem overrides granted to the Flatpak
-/// instance of BoxBuddy
+/// instance of `BoxBuddy`
 pub struct FilesystemAccess {
     /// Whether or not the user has granted `home` access
     pub home: bool,
@@ -19,7 +19,7 @@ pub struct FilesystemAccess {
     pub host: bool,
 }
 
-/// Used to represent terminals BoxBuddy can spawn
+/// Used to represent terminals `BoxBuddy` can spawn
 pub struct TerminalOption {
     /// Public-facing name of the terminal
     pub name: String,
@@ -48,7 +48,7 @@ impl FilesystemAccess {
     }
 }
 
-/// Runs shell command. Uses flatpak-spawn if BoxBuddy is running as a Flatpak
+/// Runs shell command. Uses flatpak-spawn if `BoxBuddy` is running as a Flatpak
 pub fn run_command(
     cmd_to_run: std::string::String,
     args_for_cmd: Option<&[&str]>,
@@ -77,7 +77,7 @@ pub fn get_command_output(
 
     match output {
         Ok(o) => {
-            let mut result = String::from("");
+            let mut result = String::new();
             if !o.stdout.is_empty() {
                 result = result
                     + String::from_utf8_lossy(&o.stdout).into_owned().as_ref()
@@ -106,7 +106,7 @@ pub fn get_command_output_no_err(
 
     match output {
         Ok(o) => {
-            let mut result = String::from("");
+            let mut result = String::new();
             if !o.stdout.is_empty() {
                 result = result
                     + String::from_utf8_lossy(&o.stdout).into_owned().as_ref()
@@ -117,6 +117,14 @@ pub fn get_command_output_no_err(
         }
         Err(_) => "fail".to_string(),
     }
+}
+
+/// Checks if the extension of a file (passed as a string) corresponds to a given string.
+/// Case insensitive.
+pub fn has_file_extension(path: &str, extension: &str) -> bool {
+    Path::new(path)
+        .extension()
+        .map_or(false, |ext| ext.eq_ignore_ascii_case(extension))
 }
 
 /// Gets the unicode dot character coloured with a colour similar to the distro's branding
@@ -224,7 +232,7 @@ pub fn has_distrobox_installed() -> bool {
     true
 }
 
-/// Returns a Vec of `TerminalOption`s representing all terminals supported by BoxBuddy
+/// Returns a Vec of `TerminalOption`s representing all terminals supported by `BoxBuddy`
 pub fn get_supported_terminals() -> Vec<TerminalOption> {
     vec![
         TerminalOption {
@@ -281,7 +289,7 @@ pub fn get_supported_terminals() -> Vec<TerminalOption> {
 }
 
 /// Returns the executable command and separator arg for the terminal which
-/// BoxBuddy will spawn. First tries to find the Preferred Terminal, if set,
+/// `BoxBuddy` will spawn. First tries to find the Preferred Terminal, if set,
 /// then loops through all options in order if it can't.
 /// Returns two empty strings if no supported terminal can be detected
 pub fn get_terminal_and_separator_arg() -> (String, String) {
@@ -322,7 +330,7 @@ pub fn get_terminal_and_separator_arg() -> (String, String) {
         }
     }
 
-    (String::from(""), String::from(""))
+    (String::new(), String::new())
 }
 
 /// Returns a single string of a bullet-pointed list of supported terminals
@@ -370,9 +378,9 @@ pub fn get_cpu_and_mem_usage(box_name: String) -> CpuMemUsage {
     if output_pieces.len() != 3 {
         // We failed to get the output for some reason
         return CpuMemUsage {
-            cpu: String::from(""),
-            mem: String::from(""),
-            mem_percent: String::from(""),
+            cpu: String::new(),
+            mem: String::new(),
+            mem_percent: String::new(),
         };
     }
 
@@ -402,7 +410,7 @@ pub fn get_repository_list() -> Vec<String> {
         .collect();
 }
 
-/// Whether or not BoxBuddy is running as a Flatpak
+/// Whether or not `BoxBuddy` is running as a Flatpak
 pub fn is_flatpak() -> bool {
     let fp_env = std::env::var("FLATPAK_ID").is_ok();
     if fp_env {
@@ -588,19 +596,19 @@ pub fn has_home_or_host_access() -> bool {
 #[allow(unreachable_code)]
 pub fn get_icon_file_path(icon: String) -> String {
     if is_flatpak() {
-        return format!("/app/icons/{}", icon);
+        return format!("/app/icons/{icon}");
     }
 
     // Runs only when developing
     debug_assert!({
-        return format!("icons/{}", icon);
+        return format!("icons/{icon}");
     });
 
     let home_dir = env::var("HOME").unwrap_or_else(|_| ".".to_string());
     let data_home =
         env::var("XDG_DATA_HOME").unwrap_or_else(|_| format!("{home_dir}/.local/share"));
 
-    format!("{data_home}/icons/boxbuddy/{}", icon)
+    format!("{data_home}/icons/boxbuddy/{icon}")
 }
 
 /// Get the path to the icon used in the Assemble button. Gets a light
@@ -623,7 +631,7 @@ pub fn get_download_dir_path() -> String {
     env::var("XDG_DOWNLOAD_DIR").unwrap_or_else(|_| {
         let home_dir = env::var("HOME");
         if home_dir.is_err() {
-            return String::from("");
+            return String::new();
         }
 
         let hme = home_dir.unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -52,7 +52,7 @@ impl FilesystemAccess {
 pub fn run_command(
     cmd_to_run: &str,
     args_for_cmd: Option<&[&str]>,
-) -> std::result::Result<std::process::Output, std::io::Error> {
+) -> Result<std::process::Output, std::io::Error> {
     let mut cmd = Command::new(cmd_to_run);
 
     if is_flatpak() {
@@ -69,7 +69,7 @@ pub fn run_command(
 }
 
 /// Runs shell command and returns the output as a string
-pub fn get_command_output(cmd_to_run: &str, args_for_cmd: Option<&[&str]>) -> std::string::String {
+pub fn get_command_output(cmd_to_run: &str, args_for_cmd: Option<&[&str]>) -> String {
     let output = run_command(cmd_to_run, args_for_cmd);
 
     match output {
@@ -95,10 +95,7 @@ pub fn get_command_output(cmd_to_run: &str, args_for_cmd: Option<&[&str]>) -> st
 
 /// Runs shell command and returns the output as a string, but does NOT
 /// return stderr.
-pub fn get_command_output_no_err(
-    cmd_to_run: &str,
-    args_for_cmd: Option<&[&str]>,
-) -> std::string::String {
+pub fn get_command_output_no_err(cmd_to_run: &str, args_for_cmd: Option<&[&str]>) -> String {
     let output = run_command(cmd_to_run, args_for_cmd);
 
     match output {
@@ -495,7 +492,7 @@ pub fn get_host_desktop_files() -> Vec<String> {
             env::var("XDG_DATA_HOME").unwrap_or_else(|_| format!("{home_dir}/.local/share"));
 
         let applications_dir = format!("{data_home}/applications");
-        let applications_dir_path = std::path::Path::new(&applications_dir);
+        let applications_dir_path = Path::new(&applications_dir);
 
         if applications_dir_path.exists() {
             let my_apps = std::fs::read_dir(applications_dir_path);


### PR DESCRIPTION
This is just a suggestion, your app, your choices !

Quality fixes based on `cargo clippy -- -D clippy::pedantic` :
+ in `src/main.rs`
  + no wildcard imports (https://rust-lang.github.io/rust-clippy/master/index.html#/wildcard_imports?groups=pedantic)
  + file extension check made case insensitive using std::path::Path (https://rust-lang.github.io/rust-clippy/master/index.html#/clippy::case_sensitive_file_extension_comparisons?groups=pedantic)
  + added `;` at the end of functions that return nothing (https://rust-lang.github.io/rust-clippy/master/index.html#/clippy::semicolon_if_nothing_returned?groups=pedantic)
  + avoid casting from usize (from `enumerate()`) to u32 by replacing `enumerate()` with `zip(1u32..)` (https://rust-lang.github.io/rust-clippy/master/index.html#/cast_possible_truncation?groups=pedantic)
  + `match arm` that can be replaced by `if ….is_ok()` (https://rust-lang.github.io/rust-clippy/master/index.html#/single_match_else?groups=pedantic and https://rust-lang.github.io/rust-clippy/master/index.html#/manual_assert?groups=pedantic)
+ in `src/utils.rs`
  + no wildcard imports (see above)
  + quoting of some items in the docstrings with \`…\`
  + replaced `String::from("")` with `String::new()` (https://rust-lang.github.io/rust-clippy/master/index.html#/string::ne?groups=pedantic)
  + put some variables inside of format! strings (https://rust-lang.github.io/rust-clippy/master/index.html#/uninlined_format_args?groups=pedantic)
+ in `src/distrobox_handler.rs`
  + replaced basic closures with the functions themselves (https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_closure_for_method_calls?groups=pedantic)
  + replaced `var.iter()` with `&var` when possible (https://rust-lang.github.io/rust-clippy/master/index.html#/explicit_iter_loop?groups=pedantic)
  + put some variables inside of format! strings (see above)
  + replaced `String::from("")` with `String::new()` (see above)

Also :
+ Passing arguments by reference instead of value (https://rust-lang.github.io/rust-clippy/master/index.html#/needless_pass_by_value). Required some refactor.
+ Use --long instead of -l for bash arguments. Increases readability in scripts (https://bertvv.github.io/cheat-sheets/Bash.html)
+ Created a bash script to update translations automatically based on a new potfile (similar to what poedit does when you click "tranlation -> update from pot file"). Added corresponding entry in the Makefile (`make update-translations`)
+ Updated translations with the new script