### PR TITLE
Fix Ctrl+R not working, implement common close shortcut

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ fn main() -> glib::ExitCode {
     app.connect_activate(build_ui);
 
     app.set_accels_for_action("win.refresh", &["F5", "<Ctrl>R"]);
+    app.set_accels_for_action("win.close", &["<Ctrl>Q", "<Ctrl>W"]);
 
     // Run the application
     app.run()

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,8 +58,7 @@ fn main() -> glib::ExitCode {
     app.connect_open(build_ui_as_open);
     app.connect_activate(build_ui);
 
-    app.set_accels_for_action("win.refresh", &["<Ctrl>R"]);
-    app.set_accels_for_action("win.refresh", &["F5"]);
+    app.set_accels_for_action("win.refresh", &["F5", "<Ctrl>R"]);
 
     // Run the application
     app.run()


### PR DESCRIPTION
`app.set_accels_for_action("win.refresh", &["F5"]);` was overwriting the earlier set <kbd>Ctrl</kbd>+<kbd>R</kbd> shortcut.

I also took this opportunity to implement <kbd>Ctrl</kbd>+<kbd>Q</kbd> and <kbd>Ctrl</kbd>+<kbd>W</kbd> which are common close app and close tab shortcuts, because the app does not use tabs <kbd>Ctrl</kbd>+<kbd>w</kbd> instead just closes the app .