### PR TITLE
Add subtitle for 'use init system'

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -710,6 +710,8 @@ fn create_new_distrobox(window: &ApplicationWindow) {
     let init_row = adw::SwitchRow::new();
     // TRANSLATORS - Label for Toggle when creating box to add systemd support
     init_row.set_title(&gettext("Use init system"));
+    // TRANSLATORS: Explanation of what the 'use init system' toggle does
+    init_row.set_subtitle(&gettext("Adds systemd support - ignore if you're not sure"));
     init_row.set_active(false);
 
     let loading_spinner = gtk::Spinner::new();


### PR DESCRIPTION
New users (me) have no idea what this means or if it's needed, adding a subtitle clarifies things a bit:

![image](https://github.com/user-attachments/assets/1c8092a9-b4ed-4422-82c1-89e65413cf9f)

The exact wording might need improvements, but a PR is better than just opening an issue :)