### PR TITLE
Use AdwStatusPage for the missing-dependency messages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -277,34 +277,35 @@ fn get_main_menu_model() -> gio::MenuModel {
     menu.into()
 }
 
+/// Builds the status page shown when one of BoxBuddy's dependencies is missing.
+fn build_not_installed_status_page(title: &str, body: &str) -> adw::StatusPage {
+    let status_page = adw::StatusPage::new();
+    status_page.set_icon_name(Some("dialog-warning-symbolic"));
+    status_page.set_title(title);
+    status_page.set_description(Some(body));
+    // The scroll area only hands out spare height to children which ask for it,
+    // so without this the status page would sit at the top instead of centring.
+    status_page.set_vexpand(true);
+
+    status_page
+}
+
 fn render_not_installed(scroll_area: &gtk::Box) {
-    // TRANSLATORS: Error message
-    let not_installed_lbl = gtk::Label::new(Some(&gettext("Distrobox not found!")));
-    not_installed_lbl.add_css_class("title-1");
+    // TRANSLATORS: Error message shown when distrobox is not installed
+    let title = gettext("Distrobox not found!");
+    // TRANSLATORS: Error message shown when distrobox is not installed
+    let body = gettext("Distrobox could not be found, please ensure it is installed!");
 
-    // TRANSLATORS: Error message
-    let not_installed_lbl_two = gtk::Label::new(Some(&gettext(
-        "Distrobox could not be found, please ensure it is installed!",
-    )));
-    not_installed_lbl_two.add_css_class("title-2");
-
-    scroll_area.append(&not_installed_lbl);
-    scroll_area.append(&not_installed_lbl_two);
+    scroll_area.append(&build_not_installed_status_page(&title, &body));
 }
 
 fn render_podman_not_installed(scroll_area: &gtk::Box) {
-    // TRANSLATORS: Error message
-    let not_installed_lbl = gtk::Label::new(Some(&gettext("Podman / Docker not found!")));
-    not_installed_lbl.add_css_class("title-1");
+    // TRANSLATORS: Error message shown when neither podman nor docker is installed
+    let title = gettext("Podman / Docker not found!");
+    // TRANSLATORS: Error message shown when neither podman nor docker is installed
+    let body = gettext("Could not find podman or docker, please install one of them!");
 
-    // TRANSLATORS: Error message
-    let not_installed_lbl_two = gtk::Label::new(Some(&gettext(
-        "Could not find podman or docker, please install one of them!",
-    )));
-    not_installed_lbl_two.add_css_class("title-2");
-
-    scroll_area.append(&not_installed_lbl);
-    scroll_area.append(&not_installed_lbl_two);
+    scroll_area.append(&build_not_installed_status_page(&title, &body));
 }
 
 fn load_boxes(scroll_area: &gtk::Box, window: &ApplicationWindow, active_page: Option<u32>) {


### PR DESCRIPTION
Closes #186

I ran BoxBuddy without distrobox installed and noticed the "Distrobox not found!" screen sits pinned to the top of the window, with text that runs off the edge once the window is narrow. The "Podman / Docker not found!" screen has the same problem - both are built from two bare labels appended straight to the scroll area, and a GtkBox only hands spare space to children that ask to expand, so the labels never move from the top.

Rather than patch the box by hand I switched both screens to AdwStatusPage, which is libadwaita's widget for exactly this kind of error state - it centres its content, clamps it to a readable width, wraps the description and styles the icon. Both screens now share one small helper, and the whole thing comes out slightly smaller than the code it replaces.

I tested both code paths (distrobox missing, and podman/docker missing) at 800x525 and at 420x600 - centred and wrapped in both.

The user-visible strings are unchanged, so existing translations keep working and the pot file doesn't need regenerating.

Built from source on Fedora 44 (rustc 1.97.1, gtk4 4.22.4, libadwaita 1.9.2). `make lint` is clean: fmt changes nothing and clippy reports the same 55 warnings as master, so nothing new from this branch.
