### PR TITLE
Re-check the dependencies when refreshing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -277,7 +277,17 @@ fn get_main_menu_model() -> gio::MenuModel {
     menu.into()
 }
 
+/// Removes everything currently in `container`, so a screen can be swapped for
+/// another one rather than appended below it.
+fn clear_children(container: &gtk::Box) {
+    while let Some(child) = container.first_child() {
+        container.remove(&child);
+    }
+}
+
 fn render_not_installed(scroll_area: &gtk::Box) {
+    clear_children(scroll_area);
+
     // TRANSLATORS: Error message
     let not_installed_lbl = gtk::Label::new(Some(&gettext("Distrobox not found!")));
     not_installed_lbl.add_css_class("title-1");
@@ -293,6 +303,8 @@ fn render_not_installed(scroll_area: &gtk::Box) {
 }
 
 fn render_podman_not_installed(scroll_area: &gtk::Box) {
+    clear_children(scroll_area);
+
     // TRANSLATORS: Error message
     let not_installed_lbl = gtk::Label::new(Some(&gettext("Podman / Docker not found!")));
     not_installed_lbl.add_css_class("title-1");
@@ -336,9 +348,7 @@ fn load_boxes(scroll_area: &gtk::Box, window: &ApplicationWindow, active_page: O
         tabs.append_page(&tab, Some(&tab_title));
     }
 
-    while let Some(child) = scroll_area.first_child() {
-        scroll_area.remove(&child);
-    }
+    clear_children(scroll_area);
 
     scroll_area.append(&tabs);
 
@@ -1325,7 +1335,19 @@ fn delayed_rerender(window: &ApplicationWindow, active_page: Option<u32>) {
     let main_box = window.child().unwrap().first_child().unwrap();
     let main_box_as_box = main_box.downcast::<gtk::Box>().unwrap();
 
-    load_boxes(&main_box_as_box, window, active_page);
+    // Refreshing has to re-run the same dependency check the window did when it
+    // opened, not just re-list the boxes. Asking a distrobox that is not there
+    // for its boxes simply yields an empty list, which would swap the accurate
+    // "not found" message for a "No Boxes" screen telling the user to create
+    // one. It also means the window recovers on its own once the missing
+    // command is installed.
+    if !has_distrobox_installed() {
+        render_not_installed(&main_box_as_box);
+    } else if !has_podman_or_docker_installed() {
+        render_podman_not_installed(&main_box_as_box);
+    } else {
+        load_boxes(&main_box_as_box, window, active_page);
+    }
 }
 
 fn show_no_supported_terminal_popup(window: &ApplicationWindow) {
@@ -1350,9 +1372,7 @@ fn show_no_supported_terminal_popup(window: &ApplicationWindow) {
 }
 
 fn render_no_boxes_message(main_box: &gtk::Box) {
-    while let Some(child) = main_box.first_child() {
-        main_box.remove(&child);
-    }
+    clear_children(main_box);
 
     //TRANSLATORS: Error Message
     let no_boxes_msg = gtk::Label::new(Some(&gettext("No Boxes")));


### PR DESCRIPTION
Closes #188

I found this while poking at the missing-distrobox screen: press Refresh from the menu while "Distrobox not found!" is showing and the message turns into "No Boxes - Click the + at the top-left to create your first box!". The correct diagnosis gets replaced by an instruction that can't work, and only a restart brings it back.

The cause is that Refresh goes straight to load_boxes, which only re-lists boxes and never re-runs the dependency check make_window does at startup. A missing distrobox "returns" an empty box list, so the app draws the empty state.

Refresh now runs the same check the window ran when it opened. While the dependency is missing the message stays put, and once distrobox gets installed the next Refresh picks the boxes up with no restart - I verified that by adding distrobox to PATH while the window was open.

I also made both "not found" renderers clear their container before drawing, which render_no_boxes_message already did - without it a second Refresh would stack a second copy of the message. That clearing loop existed as two hand-rolled copies, so it's now a single clear_children helper used by all four functions that swap out the window body.

How this relates to my other open PRs: each of #183, #184 and this one merges cleanly into master on its own, but #183 and this one touch the same two functions and conflict with each other. The resolution is mechanical - keep the AdwStatusPage bodies from #183 and the clear_children call from here. I merged all three locally to make sure they build and behave together, and I'll rebase whichever you'd like to land second. #184 doesn't conflict, but it decides the titlebar buttons once at startup, so with both merged, recovering via Refresh shows the boxes while Create and Upgrade stay greyed out until a restart. Happy to send a follow-up wiring the button state into this same path once #184 is settled.

Built from source on Fedora 44, rustc 1.97.1. `make lint` clean: fmt no changes, clippy same 55 warnings as master.
