### PR TITLE
Regenerate the pot file

### DIFF
--- a/po/boxbuddy.pot
+++ b/po/boxbuddy.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-15 16:47+0000\n"
+"POT-Creation-Date: 2026-08-10 19:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,177 +18,187 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:154
+#: src/main.rs:155
 msgid "Create A Distrobox"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:173
+#: src/main.rs:162
+msgid "Upgrade All Boxes"
+msgstr ""
+
+#. TRANSLATORS: Button tooltip
+#: src/main.rs:178
 msgid "Assemble A Distrobox"
 msgstr ""
 
 #. TRANSLATORS: File type
-#: src/main.rs:179
+#: src/main.rs:184
 msgid "INI-Files"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:200
+#: src/main.rs:204
 msgid "Menu"
 msgstr ""
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:253
+#: src/main.rs:256
 msgid "Refresh"
 msgstr ""
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:259
+#: src/main.rs:262
 msgid "Set Preferred Terminal"
 msgstr ""
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:266
+#: src/main.rs:269
 msgid "About BoxBuddy"
 msgstr ""
 
 #. TRANSLATORS: Menu Item
-#: src/main.rs:271
+#: src/main.rs:274
 msgid "Quit"
 msgstr ""
 
 #. TRANSLATORS: Error message
-#: src/main.rs:279
+#: src/main.rs:282
 msgid "Distrobox not found!"
 msgstr ""
 
 #. TRANSLATORS: Error message
-#: src/main.rs:284
+#: src/main.rs:287
 msgid "Distrobox could not be found, please ensure it is installed!"
 msgstr ""
 
 #. TRANSLATORS: Error message
-#: src/main.rs:294
+#: src/main.rs:297
 msgid "Podman / Docker not found!"
 msgstr ""
 
 #. TRANSLATORS: Error message
-#: src/main.rs:299
+#: src/main.rs:302
 msgid "Could not find podman or docker, please install one of them!"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:370
+#: src/main.rs:373
 msgid "Stop Box"
 msgstr ""
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:399
+#: src/main.rs:402
 msgid "Open Terminal"
 msgstr ""
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:412
+#: src/main.rs:415
 msgid "Upgrade Box"
 msgstr ""
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:424
+#: src/main.rs:427
 msgid "View Applications"
 msgstr ""
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:447
+#: src/main.rs:450
 msgid "Delete Box"
 msgstr ""
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:460
+#: src/main.rs:463
 msgid "Clone Box"
 msgstr ""
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:480
+#: src/main.rs:483
 msgid "Install .deb File"
 msgstr ""
 
 #. TRANSLATORS: Row Label
-#: src/main.rs:492
+#: src/main.rs:495
 msgid "Install .rpm File"
 msgstr ""
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:541 src/main.rs:599
+#: src/main.rs:544 src/main.rs:610
 msgid "Create New Distrobox"
 msgstr ""
 
 #. TRANSLATORS: Context label of the application doing something
-#: src/main.rs:553
+#: src/main.rs:556
 msgid "Assembling Distroboxes, please wait..."
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:607
+#: src/main.rs:618
 msgid "Create"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:612
+#: src/main.rs:624
 msgid "Additional Information"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:617 src/main.rs:1099 src/main.rs:1144 src/main.rs:1374 src/main.rs:1592
+#: src/main.rs:629 src/main.rs:1175 src/main.rs:1220 src/main.rs:1458 src/main.rs:1676
 msgid "Cancel"
 msgstr ""
 
 #. TRANSLATORS: Entry Label - Name input for new distrobox
-#: src/main.rs:651 src/main.rs:1182
+#: src/main.rs:671 src/main.rs:1258
 msgid "Name"
 msgstr ""
 
 #. TRANSLATORS: Entry Label - Select home directory for new distrobox
-#: src/main.rs:672
+#: src/main.rs:692
 msgid "Home Directory (Leave blank for default)"
 msgstr ""
 
 #. TRANSLATORS - Label for Dropdown where the user selects the container image to create
-#: src/main.rs:705
+#: src/main.rs:725
 msgid "Image"
 msgstr ""
 
 #. TRANSLATORS - Label for Toggle when creating box to add systemd support
-#: src/main.rs:712
+#: src/main.rs:732
 msgid "Use init system"
 msgstr ""
 
+#. TRANSLATORS: Explanation of what the 'use init system' toggle does
+#: src/main.rs:734
+msgid "Adds systemd support - ignore if you're not sure"
+msgstr ""
+
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:819
+#: src/main.rs:848
 msgid "Add a volume"
 msgstr ""
 
 #. TRANSLATORS: Button tooltip
-#: src/main.rs:832
+#: src/main.rs:861
 msgid "Remove volume"
 msgstr ""
 
 #. TRANSLATORS: Help text for volume input
-#: src/main.rs:845
+#: src/main.rs:874
 msgid "Enter the location to mount this folder inside your new box"
 msgstr ""
 
 #. TRANSLATORS: Subheading
-#: src/main.rs:869
+#: src/main.rs:898
 msgid "Additional Volumes:"
 msgstr ""
 
 #. TRANSLATORS: Context for the Additional Volumes subheading
-#: src/main.rs:872
+#: src/main.rs:901
 msgid "Additional directories the new box should be able to access"
 msgstr ""
 
 #. TRANSLATORS: Description of the application
-#: src/main.rs:896
+#: src/main.rs:925
 msgid "A Graphical Manager for your Distroboxes.\n"
 "    \n"
 "BoxBuddy is not partnered with or endorsed by any linux distributions or companies.\n"
@@ -197,194 +207,205 @@ msgid "A Graphical Manager for your Distroboxes.\n"
 msgstr ""
 
 #. TRANSLATORS: Window Title - shows list of installed applications in distrobox
-#: src/main.rs:930
+#: src/main.rs:960
 msgid "Installed Applications"
 msgstr ""
 
 #. TRANSLATORS: Loading Message
-#: src/main.rs:948
+#: src/main.rs:978
 msgid "Loading..."
 msgstr ""
 
-#. TRANSLATORS: Error Message
-#: src/main.rs:991
+#: src/main.rs:1026
 msgid "No Applications Installed"
 msgstr ""
 
 #. TRANSLATORS: Window Title
-#: src/main.rs:996
+#: src/main.rs:1031
 msgid "Available Applications"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1009
+#: src/main.rs:1044
 msgid "Run"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1025
+#: src/main.rs:1060
 msgid "Remove From Menu"
 msgstr ""
 
-#. TRANSLATORS: Button Label
-#: src/main.rs:1042
+#: src/main.rs:1078
 msgid "Add To Menu"
 msgstr ""
 
+#: src/main.rs:1102
+msgid "No Binaries Exported"
+msgstr ""
+
+#: src/main.rs:1110
+msgid "Exported Binaries"
+msgstr ""
+
+#. TRANSLATORS: Button Text
+#: src/main.rs:1119
+msgid "Remove"
+msgstr ""
+
 #. TRANSLATORS: Success Message
-#: src/main.rs:1073
+#: src/main.rs:1144
 msgid "App Exported!"
 msgstr ""
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1079
+#: src/main.rs:1150
 msgid "App Removed!"
 msgstr ""
 
 #. TRANSLATORS: Confirmation Dialogue
-#: src/main.rs:1090
+#: src/main.rs:1166
 msgid "Really Delete?"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1101
+#: src/main.rs:1177
 msgid "Delete"
 msgstr ""
 
 #. TRANSLATORS: Success Text
-#: src/main.rs:1114
+#: src/main.rs:1190
 msgid "Box Deleted!"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1136 src/main.rs:1140
+#: src/main.rs:1212 src/main.rs:1216
 msgid "Clone"
 msgstr ""
 
 #. TRANSLATORS: Title / Instruction label
-#: src/main.rs:1166
+#: src/main.rs:1242
 msgid "Enter the name of your new box"
 msgstr ""
 
-#: src/main.rs:1170
+#: src/main.rs:1246
 msgid "Note: Cloning can take a long time, please be patient"
 msgstr ""
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1251
+#: src/main.rs:1335
 msgid "Please install one of the supported terminals:"
 msgstr ""
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1256
+#: src/main.rs:1340
 msgid "No supported terminal found"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1261 src/main.rs:1299 src/main.rs:1317 src/main.rs:1353 src/main.rs:1532 src/main.rs:1557
+#: src/main.rs:1345 src/main.rs:1383 src/main.rs:1401 src/main.rs:1437 src/main.rs:1616 src/main.rs:1641
 msgid "Ok"
 msgstr ""
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1274
+#: src/main.rs:1358
 msgid "No Boxes"
 msgstr ""
 
 #. TRANSLATORS: Instructions
-#: src/main.rs:1277
+#: src/main.rs:1361
 msgid "Click the + at the top-left to create your first box!"
 msgstr ""
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1289
+#: src/main.rs:1373
 msgid "You appear to be using a Flatpak of BoxBuddy without filesystem access. If you wish to set a Custom Home Directory you will need to grant filesystem access. Please see the <a href='https://dvlv.github.io/BoxBuddyRS/tips'>documentation for details.</a>"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1293
+#: src/main.rs:1377
 msgid "Sandboxed Flatpak Detected"
 msgstr ""
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1308
+#: src/main.rs:1392
 msgid "Distrobox can already access folders in your home directory - even if you have specified a custom home folder"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1312
+#: src/main.rs:1396
 msgid "Volume is already accessible"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1348
+#: src/main.rs:1432
 msgid "No Suitable Boxes Found"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1370
+#: src/main.rs:1454
 msgid "Install"
 msgstr ""
 
-#: src/main.rs:1398
+#: src/main.rs:1482
 msgid "Select a box to install this file into:"
 msgstr ""
 
 #. TRANSLATORS - Label for Dropdown of existing Boxes to install .deb or .rpm into
-#: src/main.rs:1416
+#: src/main.rs:1500
 msgid "Box"
 msgstr ""
 
 #. TRANSLATORS: File type
-#: src/main.rs:1454
+#: src/main.rs:1538
 msgid "DEB Files"
 msgstr ""
 
 #. TRANSLATORS: File type
-#: src/main.rs:1489
+#: src/main.rs:1573
 msgid "RPM Files"
 msgstr ""
 
 #. TRANSLATORS: Error / Info Message
-#: src/main.rs:1522
+#: src/main.rs:1606
 msgid "This file is not accessible to Flatpak - please copy it to your Downloads folder, or allow filesystem access. Please see the <a href='https://dvlv.github.io/BoxBuddyRS/tips'>documentation for details.</a>"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1526
+#: src/main.rs:1610
 msgid "File Not Accessible"
 msgstr ""
 
 #. TRANSLATORS: Popup Heading
-#: src/main.rs:1552
+#: src/main.rs:1636
 msgid "Incorrect File Type"
 msgstr ""
 
 #. TRANSLATORS: Popup Window Title
-#: src/main.rs:1580
+#: src/main.rs:1664
 msgid "Preferred Terminal"
 msgstr ""
 
 #. TRANSLATORS: Button Label
-#: src/main.rs:1588
+#: src/main.rs:1672
 msgid "Save"
 msgstr ""
 
 #. TRANSLATORS: Instructions label
-#: src/main.rs:1609
+#: src/main.rs:1693
 msgid "Select your preferred terminal"
 msgstr ""
 
 #. TRANSLATORS: Label for Dropdown of terminals available
-#: src/main.rs:1629
+#: src/main.rs:1713
 msgid "Terminal"
 msgstr ""
 
 #. TRANSLATORS: Success Message
-#: src/main.rs:1651
+#: src/main.rs:1735
 msgid "Terminal Preference Saved!"
 msgstr ""
 
 #. TRANSLATORS: Error Message
-#: src/main.rs:1662
+#: src/main.rs:1746
 msgid "Sorry, Preference Could Not Be Saved"
 msgstr ""


### PR DESCRIPTION
Closes #189

This is just `make potfile` run on master (36a2455), nothing else by hand.

The diff looks scarier than it is. I counted: of the ~175 changed lines, 153 are refreshed `#: src/main.rs:NNN` line references plus the header timestamp. The actual substance is the five entries described in #189, added between October 2024 and September 2025 without a pot regeneration.

Nothing gets removed - I compared the msgid sets before and after and they differ by exactly those five, so there are no stale entries hiding in there. I checked the result with `msgfmt --check`. Generated with xtr 0.1.11.

A thought for prevention: a CI step that runs `make potfile` and fails on a dirty diff would catch the next string that lands without a regen.

Heads up on a small interaction: #191 also touches the pot file (it hand-adds its own two entries), so whichever of the two merges second will get a trivial conflict. Re-running `make potfile` after the first merge resolves it, and I'm happy to rebase either one.
