### PR TITLE
Allow setting a custom hostname when creating a box

### DIFF
--- a/po/boxbuddy.pot
+++ b/po/boxbuddy.pot
@@ -152,6 +152,16 @@ msgstr ""
 msgid "Home Directory (Leave blank for default)"
 msgstr ""
 
+#. TRANSLATORS: Entry Label - Custom hostname for the new distrobox
+#: src/main.rs:712
+msgid "Hostname (Leave blank for default)"
+msgstr ""
+
+#. TRANSLATORS: Help text explaining what distrobox uses when no hostname is given
+#: src/main.rs:715
+msgid "Defaults to the box name followed by your machine's hostname"
+msgstr ""
+
 #. TRANSLATORS - Label for Dropdown where the user selects the container image to create
 #: src/main.rs:705
 msgid "Image"

--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -320,10 +320,14 @@ pub fn delete_box(box_name: &str) -> String {
 
 /// Creates a new distrobox, spawns a terminal with `distrobox enter` afterwards
 /// to initialise it.
+///
+/// An empty `home_path` or `hostname` means the flag is left off entirely, so
+/// distrobox applies its own default.
 pub fn create_box(
     box_name: &str,
     image: &str,
     home_path: &str,
+    hostname: &str,
     use_init: bool,
     volumes: &[String],
 ) -> String {
@@ -341,6 +345,11 @@ pub fn create_box(
     if !home_path.is_empty() {
         args.push("--home");
         args.push(home_path);
+    }
+
+    if !hostname.is_empty() {
+        args.push("--hostname");
+        args.push(hostname);
     }
 
     if !volumes.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -705,6 +705,16 @@ fn create_new_distrobox(window: &ApplicationWindow) {
         }));
     }));
 
+    // hostname
+    let hostname_entry_row = adw::EntryRow::new();
+    hostname_entry_row.set_hexpand(true);
+    // TRANSLATORS: Entry Label - Custom hostname for the new distrobox
+    hostname_entry_row.set_title(&gettext("Hostname (Leave blank for default)"));
+    // TRANSLATORS: Help text explaining what distrobox uses when no hostname is given
+    hostname_entry_row.set_tooltip_text(Some(&gettext(
+        "Defaults to the box name followed by your machine's hostname",
+    )));
+
     // Image
     let available_images = get_available_images_with_distro_name();
     let avail_images_as_ref: Vec<&str> = available_images.iter().map(|s| s as &str).collect();
@@ -737,6 +747,7 @@ fn create_new_distrobox(window: &ApplicationWindow) {
     let loading_spinner = gtk::Spinner::new();
 
     let home_row = home_entry_row_future_clone.clone();
+    let hn_row = hostname_entry_row.clone();
     let ne_row = name_entry_row.clone();
     let is_row = image_select_row.clone();
     let in_row = init_row.clone();
@@ -746,6 +757,7 @@ fn create_new_distrobox(window: &ApplicationWindow) {
     create_btn.connect_clicked(move |btn| {
         let mut name = ne_row.text().to_string();
         let mut home_path = home_row.text().to_string();
+        let mut hostname = hn_row.text().to_string();
         let use_init = in_row.is_active();
         let mut image = is_row
             .activatable_widget()
@@ -788,6 +800,7 @@ fn create_new_distrobox(window: &ApplicationWindow) {
         }
 
         name = name.replace(' ', "-");
+        hostname = hostname.trim().replace(' ', "-");
         home_path = home_path.replace(' ', "\\ "); //Escape spaces
         image = image.split(" - ").last().unwrap().to_string();
         image = image.replace(" ✦ ", "");
@@ -797,7 +810,14 @@ fn create_new_distrobox(window: &ApplicationWindow) {
         let (sender, receiver) = async_channel::bounded(1);
 
         gio::spawn_blocking(move || {
-            create_box(&name, &image, &home_path, use_init, volumes.as_slice());
+            create_box(
+                &name,
+                &image,
+                &home_path,
+                &hostname,
+                use_init,
+                volumes.as_slice(),
+            );
             sender
                 .send_blocking(BoxCreatedMessage::Success)
                 .expect("The channel needs to be open.");
@@ -835,6 +855,7 @@ fn create_new_distrobox(window: &ApplicationWindow) {
     boxed_list.append(&init_row);
 
     boxed_list.append(&home_select_row);
+    boxed_list.append(&hostname_entry_row);
 
     main_box.append(&boxed_list);
 


### PR DESCRIPTION
Closes #176

`distrobox create` takes a --hostname flag, but there was no way to set it from the GUI. I added a Hostname row to the create dialog, right after Home Directory since it's the same kind of field: leave it blank and distrobox keeps its default of `<box-name>.<host-hostname>` - an empty value means the flag isn't passed at all.

![Create dialog with the new Hostname row](https://raw.githubusercontent.com/kacperpaczos/BoxBuddyRS/screenshots/176-create-dialog-hostname.png)

The value gets trimmed and spaces become dashes, same as the Name field already does. I deliberately didn't copy the backslash-escaping the home path uses - commands run through Command::new().args() with no shell involved, so escaping would just put a literal backslash into the argument.

To make sure the right thing actually reaches distrobox, I pointed PATH at a stub that records its argv, filled the dialog programmatically and pressed Create. With the field set to "  my host  " distrobox received `--hostname my-host`; with it empty, no --hostname at all.

About the pot file: I added the two new strings by hand (checked with msgfmt) instead of running `make potfile`, because a full regen also drags in five pre-existing strings that were never added to the pot - I wrote that up in #189 and the catch-up is #190, kept separate so each change stays reviewable on its own. Both PRs touch the pot, so whichever lands second gets a trivial conflict; happy to rebase.

One pre-existing thing I noticed but didn't touch: create_box's result is discarded and the completion channel always reports success, so an invalid hostname will fail silently, like any other creation failure today. That looks like it belongs to the "stream distrobox output to the GUI" item already on the roadmap.

Built from source on Fedora 44 (rustc 1.97.1, gtk4 4.22.4, libadwaita 1.9.2), dialog exercised under Xvfb with a stub distrobox on PATH. `make lint` clean: fmt no changes, clippy same 55 warnings as master.
