### PR TITLE
Stop a broken distrobox list row from wrecking the layout, and give every icon a fallback

### DIFF
--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -87,7 +87,7 @@ pub fn get_all_distroboxes() -> Vec<DBox> {
         }
 
         let box_line = line.split('|').map(str::trim).collect::<Vec<&str>>();
-        if box_line.len() > 3 {
+        if box_line.len() > 3 && is_short_container_id(box_line[heading_indexes.id]) {
             let status = String::from(box_line[heading_indexes.status]);
             let is_running = !status.contains("Exited") && !status.contains("Created");
 
@@ -103,6 +103,22 @@ pub fn get_all_distroboxes() -> Vec<DBox> {
     }
 
     my_boxes
+}
+
+/// Whether a column holds the 12-character short container ID which every row of
+/// `distrobox list` starts with.
+///
+/// This is how we tell a real row apart from a fragment of one. `distrobox list`
+/// asks the container runtime for the labels and mounts of each container so it
+/// can spot the mounts distrobox itself adds, then walks that output a line at a
+/// time. A label value containing a newline - the description label of
+/// `docker.io/library/ubuntu:latest` is one - therefore spreads a single
+/// container over several lines, and distrobox prints any of those fragments
+/// which happens to mention distrobox as though it were a container of its own.
+/// Such a fragment still holds enough pipes to parse, so without this check it
+/// becomes a box whose name is a wall of label text.
+fn is_short_container_id(column: &str) -> bool {
+    column.len() == 12 && column.chars().all(|c| c.is_ascii_hexdigit())
 }
 
 /// Tries to figure out the distro name of a repository URL. Returns "zunknown" if it can't
@@ -529,19 +545,10 @@ pub fn stop_box(box_name: &str) {
 /// Gets count of boxes, used to move the active page on the Notebook to the newest
 /// box after creation.
 pub fn get_number_of_boxes() -> u32 {
-    let output = get_command_output("distrobox", Some(&["list", "--no-color"]));
-
-    // I would like to just do output.lines().count() but I get inconsistent results
-    let mut count = 0;
-    for line in output.lines() {
-        if line.starts_with("ID") || line.is_empty() {
-            continue;
-        }
-
-        count += 1;
-    }
-
-    count
+    // Counting the lines of `distrobox list` ourselves would count the fragments
+    // described in `is_short_container_id` too, and the count is used to pick a
+    // tab, so it has to agree with the list the tabs were built from.
+    u32::try_from(get_all_distroboxes().len()).unwrap_or(u32::MAX)
 }
 
 /// Tries to install a .deb file in the box using `apt`. Spawns a terminal for

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use gettextrs::gettext;
+use std::path::Path;
 use std::thread;
 
 use adw::{
@@ -25,11 +26,14 @@ use distrobox_handler::{
 
 mod utils;
 use utils::{
-    get_assemble_icon, get_cpu_and_mem_usage, get_deb_distros, get_distro_img,
-    get_download_dir_path, get_my_deb_boxes, get_my_rpm_boxes, get_rpm_distros,
-    get_supported_terminals, get_supported_terminals_list, get_terminal_and_separator_arg,
-    has_distrobox_installed, has_file_extension, has_host_access, has_podman_or_docker_installed,
-    set_up_localisation,
+    get_assemble_icon, get_available_app_icon_name, get_available_icon_name, get_cpu_and_mem_usage,
+    get_deb_distros, get_distro_img, get_download_dir_path, get_my_deb_boxes, get_my_rpm_boxes,
+    get_rpm_distros, get_supported_terminals, get_supported_terminals_list,
+    get_terminal_and_separator_arg, has_distrobox_installed, has_file_extension, has_host_access,
+    has_podman_or_docker_installed, set_up_localisation, ADD_ICON_NAMES, APPLICATIONS_ICON_NAMES,
+    ASSEMBLE_FALLBACK_ICON_NAMES, COPY_ICON_NAMES, INFO_ICON_NAMES, INSTALL_PACKAGE_ICON_NAMES,
+    MENU_ICON_NAMES, OPEN_FILE_ICON_NAMES, REMOVE_ICON_NAMES, STOP_ICON_NAMES, TERMINAL_ICON_NAMES,
+    TRASH_ICON_NAMES, UPGRADE_ICON_NAMES, WARNING_ICON_NAMES,
 };
 const APP_ID: &str = "io.github.dvlv.boxbuddyrs";
 
@@ -154,20 +158,36 @@ fn build_ui_as_open(app: &Application, files: &[gio::File], _hint: &str) {
     // possibly better to just let BoxBuddy run as if there were no file
 }
 
+/// Builds the image for the Assemble button. The icon is one BoxBuddy ships
+/// itself rather than one from the icon theme, so it is loaded by path - and a
+/// path which is not there leaves `gtk::Image` drawing a broken-image
+/// placeholder, which is what the 2.6.0 Flatpak does since it contains no
+/// `/app/icons` directory at all. Fall back on a themed icon instead, so the
+/// button stays recognisable however BoxBuddy was packaged.
+fn make_assemble_image() -> gtk::Image {
+    let icon_path = get_assemble_icon();
+
+    if Path::new(&icon_path).exists() {
+        return gtk::Image::from_file(icon_path);
+    }
+
+    gtk::Image::from_icon_name(&get_available_icon_name(ASSEMBLE_FALLBACK_ICON_NAMES))
+}
+
 fn make_titlebar(window: &ApplicationWindow, dependencies_met: bool) {
-    let add_btn = gtk::Button::from_icon_name("list-add-symbolic");
+    let add_btn = gtk::Button::from_icon_name(&get_available_icon_name(ADD_ICON_NAMES));
     // TRANSLATORS: Button tooltip
     add_btn.set_tooltip_text(Some(&gettext("Create A Distrobox")));
 
     let win_clone = window.clone();
     add_btn.connect_clicked(move |_btn| create_new_distrobox(&win_clone));
 
-    let upgrade_btn = gtk::Button::from_icon_name("software-update-available-symbolic");
+    let upgrade_btn = gtk::Button::from_icon_name(&get_available_icon_name(UPGRADE_ICON_NAMES));
     // TRANSLATORS: Button tooltip
     upgrade_btn.set_tooltip_text(Some(&gettext("Upgrade All Boxes")));
     upgrade_btn.connect_clicked(move |_btn| upgrade_all_boxes());
 
-    let assemble_img = gtk::Image::from_file(get_assemble_icon());
+    let assemble_img = make_assemble_image();
     let assemble_btn = gtk::Button::new();
     assemble_btn.set_child(Some(&assemble_img));
     assemble_btn.add_css_class("flat");
@@ -175,7 +195,7 @@ fn make_titlebar(window: &ApplicationWindow, dependencies_met: bool) {
     let assemble_btn_clone = assemble_btn.clone();
     let style_manager = StyleManager::default();
     style_manager.connect_dark_notify(move |_btn| {
-        let new_image = gtk::Image::from_file(get_assemble_icon());
+        let new_image = make_assemble_image();
         assemble_btn_clone.set_child(Some(&new_image));
     });
 
@@ -203,7 +223,7 @@ fn make_titlebar(window: &ApplicationWindow, dependencies_met: bool) {
         }));
 
     let menu_btn = gtk::MenuButton::new();
-    menu_btn.set_icon_name("open-menu-symbolic");
+    menu_btn.set_icon_name(&get_available_icon_name(MENU_ICON_NAMES));
     menu_btn.set_menu_model(Some(&get_main_menu_model()));
     //TRANSLATORS: Button tooltip
     menu_btn.set_tooltip_text(Some(&gettext("Menu")));
@@ -290,6 +310,28 @@ fn get_main_menu_model() -> gio::MenuModel {
     menu.into()
 }
 
+/// Stops a box name from dictating how wide the window has to be.
+///
+/// The tab strip and the page it opens both sit inside a scroller, which sizes
+/// itself to the smallest width its child can live with - so a label showing a
+/// name of any length makes that name the minimum width of the whole window.
+/// Names within `max_chars` are left exactly as they were; a longer one gets
+/// ellipsized, and the tooltip carries the full text either way.
+fn cap_label_width(label: &gtk::Label, name: &str, max_chars: i32) {
+    label.set_tooltip_text(Some(name));
+
+    if i32::try_from(name.chars().count()).unwrap_or(i32::MAX) > max_chars {
+        label.set_ellipsize(gtk::pango::EllipsizeMode::End);
+        label.set_max_width_chars(max_chars);
+        // The cap on its own only limits what the label asks for; an ellipsizing
+        // label is also happy to shrink all the way down to a lone "...", which
+        // would let the tab strip collapse to nothing. Half the cap gives it a
+        // floor to stop at while still letting it give ground when the window is
+        // too narrow for the full width.
+        label.set_width_chars(max_chars / 2);
+    }
+}
+
 /// Removes everything currently in `container`, so a screen can be swapped for
 /// another one rather than appended below it.
 fn clear_children(container: &gtk::Box) {
@@ -301,7 +343,7 @@ fn clear_children(container: &gtk::Box) {
 /// Builds the status page shown when one of BoxBuddy's dependencies is missing.
 fn build_not_installed_status_page(title: &str, body: &str) -> adw::StatusPage {
     let status_page = adw::StatusPage::new();
-    status_page.set_icon_name(Some("dialog-warning-symbolic"));
+    status_page.set_icon_name(Some(&get_available_icon_name(WARNING_ICON_NAMES)));
     status_page.set_title(title);
     status_page.set_description(Some(body));
     // The scroll area only hands out spare height to children which ask for it,
@@ -313,7 +355,7 @@ fn build_not_installed_status_page(title: &str, body: &str) -> adw::StatusPage {
 
 fn render_not_installed(scroll_area: &gtk::Box) {
     clear_children(scroll_area);
-  
+
     // TRANSLATORS: Error message shown when distrobox is not installed
     let title = gettext("Distrobox not found!");
     // TRANSLATORS: Error message shown when distrobox is not installed
@@ -353,6 +395,8 @@ fn load_boxes(scroll_area: &gtk::Box, window: &ApplicationWindow, active_page: O
 
         let tab_title = gtk::Box::new(Orientation::Horizontal, 5);
         let tab_title_lbl = gtk::Label::new(Some(&dbox.name));
+        cap_label_width(&tab_title_lbl, &dbox.name, 20);
+
         let tab_title_img = gtk::Label::new(None);
         tab_title_img.set_markup(&get_distro_img(&dbox.distro));
 
@@ -387,12 +431,15 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
     page_img.set_markup(&get_distro_img(&dbox.distro));
     let page_title = gtk::Label::new(Some(&dbox.name));
     page_title.add_css_class("title-1");
+    // As on the tab, a long name has to give way rather than shove the status
+    // label and the Stop button off the end of the row.
+    cap_label_width(&page_title, &dbox.name, 30);
 
     let page_status = gtk::Label::new(Some(&dbox.status));
     page_status.set_halign(Align::End);
     page_status.set_hexpand(true);
 
-    let stop_btn = gtk::Button::from_icon_name("media-playback-stop");
+    let stop_btn = gtk::Button::from_icon_name(&get_available_icon_name(STOP_ICON_NAMES));
     // TRANSLATORS: Button tooltip
     stop_btn.set_tooltip_text(Some(&gettext("Stop Box")));
 
@@ -419,7 +466,8 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
     boxed_list.add_css_class("boxed-list");
 
     // Terminal Icon
-    let open_terminal_icon = gtk::Image::from_icon_name("utilities-terminal-symbolic");
+    let open_terminal_icon =
+        gtk::Image::from_icon_name(&get_available_icon_name(TERMINAL_ICON_NAMES));
 
     let open_terminal_row = ActionRow::new();
     // TRANSLATORS: Row Label
@@ -432,7 +480,7 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
         .connect_activated(move |_row| on_open_terminal_clicked(term_bn_clone.clone()));
 
     // Upgrade Icon
-    let upgrade_icon = gtk::Image::from_icon_name("software-update-available-symbolic");
+    let upgrade_icon = gtk::Image::from_icon_name(&get_available_icon_name(UPGRADE_ICON_NAMES));
 
     let upgrade_row = ActionRow::new();
     // TRANSLATORS: Row Label
@@ -444,7 +492,8 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
     upgrade_row.connect_activated(move |_row| on_upgrade_clicked(&up_bn_clone));
 
     // Show Applications Icon
-    let show_applications_icon = gtk::Image::from_icon_name("application-x-executable-symbolic");
+    let show_applications_icon =
+        gtk::Image::from_icon_name(&get_available_icon_name(APPLICATIONS_ICON_NAMES));
 
     let show_applications_row = ActionRow::new();
     // TRANSLATORS: Row Label
@@ -460,14 +509,16 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
 
     // Install Deb Icon
     let deb_bn_clone = box_name.clone();
-    let install_deb_icon = gtk::Image::from_icon_name("system-software-install-symbolic");
+    let install_deb_icon =
+        gtk::Image::from_icon_name(&get_available_icon_name(INSTALL_PACKAGE_ICON_NAMES));
 
     // Install RPM Icon
     let rpm_bn_clone = box_name.clone();
-    let install_rpm_icon = gtk::Image::from_icon_name("system-software-install-symbolic");
+    let install_rpm_icon =
+        gtk::Image::from_icon_name(&get_available_icon_name(INSTALL_PACKAGE_ICON_NAMES));
 
     // Delete Icon
-    let delete_icon = gtk::Image::from_icon_name("user-trash-symbolic");
+    let delete_icon = gtk::Image::from_icon_name(&get_available_icon_name(TRASH_ICON_NAMES));
 
     let delete_row = ActionRow::new();
     //TRANSLATORS: Row Label
@@ -480,7 +531,7 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
     delete_row.connect_activated(move |_row| on_delete_clicked(&win_clone, del_bn_clone.clone()));
 
     // Clone Box Icon
-    let clone_icon = gtk::Image::from_icon_name("edit-copy-symbolic");
+    let clone_icon = gtk::Image::from_icon_name(&get_available_icon_name(COPY_ICON_NAMES));
 
     let clone_row = ActionRow::new();
     //TRANSLATORS: Row Label
@@ -643,7 +694,7 @@ fn create_new_distrobox(window: &ApplicationWindow) {
     create_btn.add_css_class("suggested-action");
     create_btn.set_sensitive(false);
 
-    let info_btn = gtk::Button::from_icon_name("dialog-information-symbolic");
+    let info_btn = gtk::Button::from_icon_name(&get_available_icon_name(INFO_ICON_NAMES));
     // TRANSLATORS: Button Label
     info_btn.set_tooltip_text(Some(&gettext("Additional Information")));
     let win_clone = window.clone();
@@ -695,7 +746,8 @@ fn create_new_distrobox(window: &ApplicationWindow) {
     name_entry_row.set_title(&gettext("Name"));
 
     // custom home
-    let choose_home_btn = gtk::Button::from_icon_name("document-open-symbolic");
+    let choose_home_btn =
+        gtk::Button::from_icon_name(&get_available_icon_name(OPEN_FILE_ICON_NAMES));
     choose_home_btn.set_margin_top(10);
     choose_home_btn.set_margin_bottom(10);
     let home_select_row = adw::ActionRow::new();
@@ -887,7 +939,7 @@ fn create_new_distrobox(window: &ApplicationWindow) {
     if has_host_access() {
         let volume_box_list_clone = volume_box_list.clone();
 
-        let volume_add_btn = gtk::Button::from_icon_name("list-add-symbolic");
+        let volume_add_btn = gtk::Button::from_icon_name(&get_available_icon_name(ADD_ICON_NAMES));
         volume_add_btn.add_css_class("flat");
         // TRANSLATORS: Button tooltip
         volume_add_btn.set_tooltip_text(Some(&gettext("Add a volume")));
@@ -901,7 +953,7 @@ fn create_new_distrobox(window: &ApplicationWindow) {
                     if volume_path.starts_with("/home/") || volume_path.starts_with("/var/home/") {
                         show_volume_is_in_user_home_popup(&window);
                     } else {
-                        let volume_remove_btn = gtk::Button::from_icon_name("list-remove-symbolic");
+                        let volume_remove_btn = gtk::Button::from_icon_name(&get_available_icon_name(REMOVE_ICON_NAMES));
                         // TRANSLATORS: Button tooltip
                         volume_remove_btn.set_tooltip_text(Some(&gettext("Remove volume")));
                         volume_remove_btn.add_css_class("flat");
@@ -1083,7 +1135,9 @@ fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {
                                 let row = adw::ActionRow::new();
                                 row.set_title(&markup_escape_text(&app.name.to_string()));
 
-                                let img = gtk::Image::from_icon_name(&app.icon);
+                                let img = gtk::Image::from_icon_name(&get_available_app_icon_name(
+                                    &app.icon,
+                                ));
 
                                 //TRANSLATORS: Button Label
                                 let run_btn = gtk::Button::with_label(&gettext("Run"));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -122,6 +122,89 @@ pub fn has_file_extension(path: &str, extension: &str) -> bool {
         .map_or(false, |ext| ext.eq_ignore_ascii_case(extension))
 }
 
+/// Best-first alternatives for every icon BoxBuddy asks a theme for. Meant to be
+/// passed to `get_available_icon_name`, which picks the first one the user's
+/// theme can actually draw.
+///
+/// The lists cover more than the names known to be missing today, because a
+/// theme is free to omit any of them and the cost of an alternative is nothing.
+/// The ones we know go missing: `software-update-available-symbolic`,
+/// `system-software-install-symbolic`, `application-x-executable-symbolic`,
+/// `dialog-warning-symbolic` and `dialog-information-symbolic` are absent from
+/// breeze, and `media-playback-stop` is absent from Adwaita.
+pub const UPGRADE_ICON_NAMES: &[&str] = &[
+    "software-update-available-symbolic",
+    "system-software-update-symbolic",
+    "system-software-update",
+];
+pub const WARNING_ICON_NAMES: &[&str] = &["dialog-warning-symbolic", "dialog-warning"];
+pub const INFO_ICON_NAMES: &[&str] = &["dialog-information-symbolic", "dialog-information"];
+pub const APPLICATIONS_ICON_NAMES: &[&str] = &[
+    "application-x-executable-symbolic",
+    "application-x-executable",
+    "system-run-symbolic",
+];
+pub const INSTALL_PACKAGE_ICON_NAMES: &[&str] = &[
+    "system-software-install-symbolic",
+    "system-software-install",
+    "install-symbolic",
+];
+pub const ADD_ICON_NAMES: &[&str] = &["list-add-symbolic", "list-add"];
+pub const REMOVE_ICON_NAMES: &[&str] = &["list-remove-symbolic", "list-remove"];
+pub const MENU_ICON_NAMES: &[&str] = &["open-menu-symbolic", "open-menu", "view-more-symbolic"];
+pub const STOP_ICON_NAMES: &[&str] = &["media-playback-stop-symbolic", "media-playback-stop"];
+pub const TERMINAL_ICON_NAMES: &[&str] = &["utilities-terminal-symbolic", "utilities-terminal"];
+pub const TRASH_ICON_NAMES: &[&str] =
+    &["user-trash-symbolic", "user-trash", "edit-delete-symbolic"];
+pub const COPY_ICON_NAMES: &[&str] = &["edit-copy-symbolic", "edit-copy"];
+pub const OPEN_FILE_ICON_NAMES: &[&str] = &[
+    "document-open-symbolic",
+    "document-open",
+    "folder-open-symbolic",
+];
+/// Stands in for BoxBuddy's own Assemble icon if that file cannot be found.
+pub const ASSEMBLE_FALLBACK_ICON_NAMES: &[&str] = &[
+    "applications-engineering-symbolic",
+    "system-run-symbolic",
+    "system-run",
+];
+
+/// Returns whichever of `icon_names` the user's icon theme is actually able to
+/// draw, so a button does not end up showing a broken-image placeholder.
+///
+/// GTK does not quietly fall back to Adwaita for a name the current theme has
+/// never heard of, and several themes are missing names BoxBuddy asks for -
+/// breeze, the KDE default, has no `software-update-available-symbolic` - so we
+/// list the alternatives we know about and pick one that exists. Returns the
+/// first name if none of them are found, leaving the behaviour as it was.
+pub fn get_available_icon_name(icon_names: &[&str]) -> String {
+    if let Some(display) = gtk::gdk::Display::default() {
+        let theme = gtk::IconTheme::for_display(&display);
+
+        for name in icon_names {
+            if theme.has_icon(name) {
+                return (*name).to_string();
+            }
+        }
+    }
+
+    icon_names[0].to_string()
+}
+
+/// Like `get_available_icon_name`, but for an icon name BoxBuddy has no say over:
+/// the `Icon=` line of a desktop file found inside a box.
+///
+/// Such an icon is installed in the box rather than on the host, so the host's
+/// theme has usually never heard of it - and the desktop file is even allowed to
+/// name a file path rather than a theme icon - which would leave a broken-image
+/// placeholder next to the application. Fall back to a generic application icon.
+pub fn get_available_app_icon_name(desktop_file_icon: &str) -> String {
+    let mut icon_names = vec![desktop_file_icon];
+    icon_names.extend_from_slice(APPLICATIONS_ICON_NAMES);
+
+    get_available_icon_name(&icon_names)
+}
+
 /// Gets the unicode dot character coloured with a colour similar to the distro's branding
 pub fn get_distro_img(distro: &str) -> String {
     let distro_colours: HashMap<&str, &str> = HashMap::from([


### PR DESCRIPTION
Fixes #192
Fixes #193

Two unrelated bugs that happen to show up in the same screenshot.

### Phantom boxes and the blown-out layout (#192)

`distrobox list` puts each container's labels and mounts in the output it walks line by line, so an image whose label value spans lines — `docker.io/library/ubuntu:latest` has a five-line `org.opencontainers.image.description` — gets reprinted as several rows. `get_all_distroboxes` accepted anything with more than three columns, so each leftover fragment became a box named after a wall of label text, and since the tab strip sits in a `GtkScrolledWindow` and is only ever as wide as its widest label asks to be, the strip grew until it covered the window and pushed every box's page off the right-hand edge.

Every real row starts with the 12-character short container ID, so `is_short_container_id` now gates that. `get_number_of_boxes` counts the parsed list instead of the raw lines, so the count used to pick a tab after creating a box agrees with the tabs that exist.

`cap_label_width` bounds what a name may demand, independently of the above: a long-but-legitimate box name could crowd out the page the same way. Names within the cap are left exactly as they were, so nothing changes for normal names; longer ones ellipsize with the full text in a tooltip, and can give ground down to half the cap when the window is narrow.

### Broken-image placeholders instead of icons (#193)

A GTK icon theme only searches the chain in its own `index.theme`, and `breeze` declares `Inherits=hicolor` — it never reaches Adwaita, so a name it omits is drawn as `image-missing`. `breeze` omits `software-update-available-symbolic`, `system-software-install-symbolic`, `application-x-executable-symbolic`, `dialog-warning-symbolic` and `dialog-information-symbolic`. Going the other way, Adwaita has no `media-playback-stop` — only the symbolic variant — so Stop Box relied on the optional `adwaita-icon-theme-legacy` package.

`get_available_icon_name` asks `gtk_icon_theme_has_icon` and takes the first name from a short best-first list, so icons stay under the user's theme's control rather than being shipped as SVGs. Every icon name now goes through it; `grep` for a literal in `from_icon_name`/`set_icon_name` finds none left.

Two more that are not theme-related:

- `get_available_app_icon_name` covers the `Icon=` name read from a desktop file inside a box. That icon lives in the container, not on the host, so it usually resolves to nothing — and a desktop file may put a file path there, which `from_icon_name` cannot use either. Falls back to a generic application icon.
- `make_assemble_image` falls back to a themed icon when the bundled `build-alt-symbolic.svg` is not on disk. The Flathub 2.6.0 build ships no `/app/icons` directory, so `Image::from_file` was drawing a placeholder for every Flatpak user. Worth checking the Flathub manifest against the one in this repo separately — this only stops it being visible.

### Testing

- Reproduced the original layout on a local build of `master` (37ee7c7) and confirmed the fix against the same three real boxes.
- Checked the width cap with a stub `distrobox` in `PATH` emitting a 60-character box name alongside a fragment row: the fragment is dropped, the name ellipsizes, and nothing overflows horizontally.
- Confirmed the Assemble fallback by running from a working directory where `./icons` does not resolve.
- `cargo build`, `cargo clippy` and `cargo fmt --check` are unchanged from `master` in warning and lint counts. `cargo fmt` also removed some trailing whitespace in `render_not_installed` that was failing `--check` on `master`.
