### PR TITLE
Clear the loading heading once the application list arrives

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -313,7 +313,7 @@ fn build_not_installed_status_page(title: &str, body: &str) -> adw::StatusPage {
 
 fn render_not_installed(scroll_area: &gtk::Box) {
     clear_children(scroll_area);
-  
+
     // TRANSLATORS: Error message shown when distrobox is not installed
     let title = gettext("Distrobox not found!");
     // TRANSLATORS: Error message shown when distrobox is not installed
@@ -1064,6 +1064,11 @@ fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {
                     AppsFetchMessage::AppsFetched(apps, binaries) => {
                         loading_spinner.stop();
                         scroll_area.remove(&loading_spinner);
+                        // The heading has to go along with the spinner. Retitling
+                        // it below only covers the case where there are apps to
+                        // list, which left "Loading..." sitting above the "no
+                        // applications" message for good.
+                        scroll_area.remove(&loading_lbl);
 
                         if apps.is_empty() {
                             //TRANSLATORS: Error Message
@@ -1073,7 +1078,10 @@ fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {
                             scroll_area.append(&no_apps_lbl);
                         } else {
                             //TRANSLATORS: Window Title
-                            loading_lbl.set_text(&gettext("Available Applications"));
+                            let available_lbl =
+                                gtk::Label::new(Some(&gettext("Available Applications")));
+                            available_lbl.add_css_class("title-2");
+                            scroll_area.append(&available_lbl);
 
                             let boxed_list = gtk::ListBox::new();
                             boxed_list.set_selection_mode(gtk::SelectionMode::None);
@@ -1107,13 +1115,16 @@ fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {
                                     remove_from_menu_btn.set_width_request(200);
 
                                     let box_name_clone = box_name.clone();
-                                    let loading_lbl_clone = loading_lbl.clone();
+                                    // The heading doubles as the place the
+                                    // export confirmation is written, so it has
+                                    // to be the one still in the window.
+                                    let success_lbl = available_lbl.clone();
                                     let app_clone = app.clone();
                                     remove_from_menu_btn.connect_clicked(move |_btn| {
                                         remove_app_from_menu(
                                             &app_clone,
                                             &box_name_clone,
-                                            &loading_lbl_clone.clone(),
+                                            &success_lbl.clone(),
                                         );
                                     });
                                     row.add_suffix(&remove_from_menu_btn);
@@ -1125,13 +1136,13 @@ fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {
                                     add_menu_btn.set_width_request(200);
 
                                     let box_name_clone = box_name.clone();
-                                    let loading_lbl_clone = loading_lbl.clone();
+                                    let success_lbl = available_lbl.clone();
                                     let app_clone = app.clone();
                                     add_menu_btn.connect_clicked(move |_btn| {
                                         add_app_to_menu(
                                             &app_clone,
                                             &box_name_clone,
-                                            &loading_lbl_clone.clone(),
+                                            &success_lbl.clone(),
                                         );
                                     });
                                     row.add_suffix(&add_menu_btn);


### PR DESCRIPTION
Fixes #195

The View Applications window adds "Loading..." and a spinner to the scroll area, then gets rid of the label by retitling it to "Available Applications" once the results arrive — but only in the branch that has applications to list. A box with none keeps the heading, so it ends up reading "Loading..." directly above "No Applications Installed", and a finished window looks like a stuck one.

That is easy to hit rather than a corner case: `docker.io/library/ubuntu:latest` and friends carry no `.desktop` files in `/usr/share/applications` at all, so every box built from a plain base image lands in the empty branch.

The label now goes when the spinner goes, and the populated branch gets a heading of its own.

One thing worth pointing out for review: that heading is also passed to `add_app_to_menu` and `remove_app_from_menu` as the label they write "App Exported!" / "App Removed!" into. Removing the loading label without redirecting those would leave both buttons doing their work with nothing shown for it, so they now take the label that is still in the window.

`cargo fmt` also dropped some trailing whitespace in `render_not_installed`, which is why that unrelated line is in the diff. The same tidy-up is in #194, so whichever lands first the other merges cleanly.

### Testing

Built and ran against boxes with no applications, which is the case that was broken. The populated branch is unchanged in shape — same heading text, same list — so the export confirmations behave as before, but I do not have a box with exported desktop apps here to click through, so that path is reasoned rather than exercised.
