### PR TITLE
Give the applications window sections, and a size that fits it

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use gettextrs::gettext;
 use std::thread;
 
 use adw::{
-    prelude::{ActionRowExt, MessageDialogExt, PreferencesRowExt},
+    prelude::{ActionRowExt, MessageDialogExt, PreferencesGroupExt, PreferencesRowExt},
     ActionRow, Application, StyleManager, ToastOverlay,
 };
 use gtk::{
@@ -999,13 +999,36 @@ fn on_upgrade_clicked(box_name: &str) {
     upgrade_box(box_name);
 }
 
+/// Roughly the height one application row takes, used to give the applications
+/// window a size that follows its contents instead of a fixed guess.
+const APPS_ROW_HEIGHT: i32 = 64;
+/// Room on top of the rows for the section headings and the window's margins.
+const APPS_WINDOW_CHROME: i32 = 120;
+/// Floor and ceiling for that calculation, so one row does not give a sliver of
+/// a window and forty do not give one taller than the screen.
+const APPS_WINDOW_MIN_CONTENT: i32 = 220;
+const APPS_WINDOW_MAX_CONTENT: i32 = 620;
+
+/// A centred placeholder for a window with nothing to show, so the message sits
+/// in the middle of the space rather than clinging to the top of it.
+fn build_empty_state_page(title: &str) -> adw::StatusPage {
+    let status_page = adw::StatusPage::new();
+    status_page.set_title(title);
+    status_page.set_vexpand(true);
+
+    status_page
+}
+
 fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {
     let apps_popup = gtk::Window::builder()
         // TRANSLATORS: Window Title - shows list of installed applications in distrobox
         .title(gettext("Installed Applications"))
         .transient_for(window)
-        .default_width(700)
-        .default_height(350)
+        // A row is a name, a Run button and an Add To Menu button 200px wide, so
+        // the old 700 left the name almost nothing. Height is a starting point
+        // only - it grows to fit once the list has been fetched.
+        .default_width(860)
+        .default_height(400)
         .modal(true)
         .build();
 
@@ -1023,6 +1046,14 @@ fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {
     let loading_lbl = gtk::Label::new(Some(&gettext("Loading...")));
     loading_lbl.add_css_class("title-2");
 
+    // Kept together in a box of their own so the pair can be centred, and so
+    // clearing the loading state is one removal rather than two.
+    let loading_box = gtk::Box::new(Orientation::Vertical, 10);
+    loading_box.set_vexpand(true);
+    loading_box.set_valign(Align::Center);
+    loading_box.append(&loading_lbl);
+    loading_box.append(&loading_spinner);
+
     let scrolled_win = gtk::ScrolledWindow::new();
     scrolled_win.set_vexpand(true);
     scrolled_win.set_hexpand(true);
@@ -1031,8 +1062,7 @@ fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {
     scroll_area.set_vexpand(true);
     scroll_area.set_hexpand(true);
 
-    scroll_area.append(&loading_lbl);
-    scroll_area.append(&loading_spinner);
+    scroll_area.append(&loading_box);
 
     scrolled_win.set_child(Some(&scroll_area));
 
@@ -1058,34 +1088,55 @@ fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {
     glib::spawn_future_local(clone!(
         #[weak]
         scroll_area,
+        #[weak]
+        scrolled_win,
         async move {
             while let Ok(msg) = receiver.recv().await {
                 match msg {
                     AppsFetchMessage::AppsFetched(apps, binaries) => {
                         loading_spinner.stop();
-                        scroll_area.remove(&loading_spinner);
-                        // The heading has to go along with the spinner. Retitling
-                        // it below only covers the case where there are apps to
-                        // list, which left "Loading..." sitting above the "no
-                        // applications" message for good.
-                        scroll_area.remove(&loading_lbl);
+                        scroll_area.remove(&loading_box);
 
-                        if apps.is_empty() {
+                        // Give the window a height that follows what it is
+                        // showing. It cannot be done up front, because the
+                        // window is presented before this fetch finishes, and
+                        // set_default_size does nothing once a window is mapped
+                        // - but raising the scroller's minimum still makes the
+                        // window grow.
+                        let rows = i32::try_from(apps.len() + binaries.len())
+                            .unwrap_or(APPS_WINDOW_MAX_CONTENT);
+                        let wanted = rows
+                            .saturating_mul(APPS_ROW_HEIGHT)
+                            .saturating_add(APPS_WINDOW_CHROME);
+                        scrolled_win.set_min_content_height(
+                            wanted.clamp(APPS_WINDOW_MIN_CONTENT, APPS_WINDOW_MAX_CONTENT),
+                        );
+
+                        // With both lists empty there is nothing to put in
+                        // sections, and two empty headings would just split the
+                        // window between them. One centred message says the same
+                        // thing, the way the rest of the app does it.
+                        if apps.is_empty() && binaries.is_empty() {
                             //TRANSLATORS: Error Message
-                            let no_apps_lbl =
-                                gtk::Label::new(Some(&gettext("No Applications Installed")));
-                            no_apps_lbl.add_css_class("title-2");
-                            scroll_area.append(&no_apps_lbl);
+                            scroll_area.append(&build_empty_state_page(&gettext(
+                                "No Applications Installed",
+                            )));
                         } else {
+                            let apps_group = adw::PreferencesGroup::new();
                             //TRANSLATORS: Window Title
-                            let available_lbl =
-                                gtk::Label::new(Some(&gettext("Available Applications")));
-                            available_lbl.add_css_class("title-2");
-                            scroll_area.append(&available_lbl);
+                            apps_group.set_title(&gettext("Available Applications"));
 
-                            let boxed_list = gtk::ListBox::new();
-                            boxed_list.set_selection_mode(gtk::SelectionMode::None);
-                            boxed_list.add_css_class("boxed-list");
+                            // Export confirmations used to overwrite the heading
+                            // itself. A label beside it says the same thing
+                            // without the section losing its name.
+                            let available_lbl = gtk::Label::new(None);
+                            apps_group.set_header_suffix(Some(&available_lbl));
+
+                            if apps.is_empty() {
+                                //TRANSLATORS: Error Message
+                                apps_group
+                                    .set_description(Some(&gettext("No Applications Installed")));
+                            }
 
                             for app in apps {
                                 let row = adw::ActionRow::new();
@@ -1148,28 +1199,22 @@ fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {
                                     row.add_suffix(&add_menu_btn);
                                 }
 
-                                boxed_list.append(&row);
-                                scroll_area.append(&boxed_list);
+                                apps_group.add(&row);
                             }
-                        }
-                        if binaries.is_empty() {
-                            //TRANSLATORS: Error Message
-                            let no_binaries_lbl =
-                                gtk::Label::new(Some(&gettext("No Binaries Exported")));
-                            no_binaries_lbl.add_css_class("title-2");
-                            scroll_area.append(&no_binaries_lbl);
-                        } else {
-                            let bin_boxed_list = gtk::ListBox::new();
-                            bin_boxed_list.set_selection_mode(gtk::SelectionMode::None);
-                            bin_boxed_list.add_css_class("boxed-list");
 
-                            let bin_title = gtk::Label::new(Some(&gettext("Exported Binaries")));
-                            bin_title.add_css_class("title-2");
+                            scroll_area.append(&apps_group);
+
+                            let bins_group = adw::PreferencesGroup::new();
+                            bins_group.set_title(&gettext("Exported Binaries"));
+
+                            if binaries.is_empty() {
+                                //TRANSLATORS: Error Message
+                                bins_group.set_description(Some(&gettext("No Binaries Exported")));
+                            }
 
                             for binary in binaries {
                                 let row = adw::ActionRow::new();
                                 row.set_title(&markup_escape_text(&binary.to_string()));
-                                bin_boxed_list.append(&row);
 
                                 // TRANSLATORS: Button Text
                                 let remove_btn = gtk::Button::with_label(&gettext("Remove"));
@@ -1183,9 +1228,10 @@ fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {
                                     btn.set_sensitive(false);
                                 });
                                 row.add_suffix(&remove_btn);
+                                bins_group.add(&row);
                             }
-                            scroll_area.append(&bin_title);
-                            scroll_area.append(&bin_boxed_list);
+
+                            scroll_area.append(&bins_group);
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,7 +313,7 @@ fn build_not_installed_status_page(title: &str, body: &str) -> adw::StatusPage {
 
 fn render_not_installed(scroll_area: &gtk::Box) {
     clear_children(scroll_area);
-  
+
     // TRANSLATORS: Error message shown when distrobox is not installed
     let title = gettext("Distrobox not found!");
     // TRANSLATORS: Error message shown when distrobox is not installed
@@ -1064,6 +1064,11 @@ fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {
                     AppsFetchMessage::AppsFetched(apps, binaries) => {
                         loading_spinner.stop();
                         scroll_area.remove(&loading_spinner);
+                        // The heading has to go along with the spinner. Retitling
+                        // it below only covers the case where there are apps to
+                        // list, which left "Loading..." sitting above the "no
+                        // applications" message for good.
+                        scroll_area.remove(&loading_lbl);
 
                         if apps.is_empty() {
                             //TRANSLATORS: Error Message
@@ -1073,7 +1078,10 @@ fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {
                             scroll_area.append(&no_apps_lbl);
                         } else {
                             //TRANSLATORS: Window Title
-                            loading_lbl.set_text(&gettext("Available Applications"));
+                            let available_lbl =
+                                gtk::Label::new(Some(&gettext("Available Applications")));
+                            available_lbl.add_css_class("title-2");
+                            scroll_area.append(&available_lbl);
 
                             let boxed_list = gtk::ListBox::new();
                             boxed_list.set_selection_mode(gtk::SelectionMode::None);
@@ -1107,13 +1115,16 @@ fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {
                                     remove_from_menu_btn.set_width_request(200);
 
                                     let box_name_clone = box_name.clone();
-                                    let loading_lbl_clone = loading_lbl.clone();
+                                    // The heading doubles as the place the
+                                    // export confirmation is written, so it has
+                                    // to be the one still in the window.
+                                    let success_lbl = available_lbl.clone();
                                     let app_clone = app.clone();
                                     remove_from_menu_btn.connect_clicked(move |_btn| {
                                         remove_app_from_menu(
                                             &app_clone,
                                             &box_name_clone,
-                                            &loading_lbl_clone.clone(),
+                                            &success_lbl.clone(),
                                         );
                                     });
                                     row.add_suffix(&remove_from_menu_btn);
@@ -1125,13 +1136,13 @@ fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {
                                     add_menu_btn.set_width_request(200);
 
                                     let box_name_clone = box_name.clone();
-                                    let loading_lbl_clone = loading_lbl.clone();
+                                    let success_lbl = available_lbl.clone();
                                     let app_clone = app.clone();
                                     add_menu_btn.connect_clicked(move |_btn| {
                                         add_app_to_menu(
                                             &app_clone,
                                             &box_name_clone,
-                                            &loading_lbl_clone.clone(),
+                                            &success_lbl.clone(),
                                         );
                                     });
                                     row.add_suffix(&add_menu_btn);


### PR DESCRIPTION
Fixes #198

Three things I ran into as soon as I had a box with real applications in it rather than an empty one.

**Size.** It was `700x350` whatever was in the window. A row is the name, a Run button and an Add To Menu button 200px wide, so at 700 across the name got the leftovers. Width starts at 860 now, and the height follows the row count once the fetch comes back. That last part needs doing indirectly: the window is presented before the fetch finishes and `gtk_window_set_default_size` is a no-op on a mapped window, so this raises `min_content_height` on the scroller instead, which does make the window grow. Clamped at both ends so one row isn't a sliver and forty aren't taller than the screen.

**Sections.** "Available Applications" and "Exported Binaries" were loose `title-2` labels between the lists. They are `AdwPreferencesGroup` titles now. That also removes the hand-rolled `GtkListBox` plus `boxed-list` class, and incidentally fixes a small pre-existing bug: `scroll_area.append(&boxed_list)` sat *inside* the `for app` loop, so with more than one application the same widget was appended repeatedly.

**Empty states.** They clung to the top with blank space underneath. With both lists empty there's now a single centred `AdwStatusPage` instead of two headings splitting the window between them — the same shape the missing-dependency screens already use, so this is the third empty screen behaving like the other two rather than a third variant. When only one list is empty, its group carries the message as a description, which keeps the other section visible.

One knock-on worth flagging: export confirmations used to be written over the "Available Applications" heading, so the section lost its name in order to say "App Exported!". They now go to a label in the group's header suffix, which shows both at once.

No new translatable strings — every message reuses an existing msgid.

### Stacked on #197

This branches off `fix-loading-label`, so that commit is included in the diff. The two touch the same function and would conflict otherwise. Merge #197 first and I'll rebase this onto master, or take this one and #197 comes along with it — whichever suits you.

### Testing

Builds clean and runs; warning and clippy counts are unchanged from master, `cargo fmt --check` passes. I haven't been able to photograph the reworked window itself, so the visual result is reasoned from the widget changes rather than confirmed on screen — worth a look before merging.
