### PR TITLE
Show a coloured bar and distro logo in the box header

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,9 @@ use distrobox_handler::{
 
 mod utils;
 use utils::{
-    get_assemble_icon, get_cpu_and_mem_usage, get_deb_distros, get_distro_color,
-    get_distro_icon_name, get_distro_img, get_download_dir_path, get_my_deb_boxes, get_my_rpm_boxes,
-    get_rpm_distros, get_supported_terminals, get_supported_terminals_list,
+    get_assemble_icon, get_cpu_and_mem_usage, get_deb_distros, get_distro_color_css,
+    get_distro_icon_name, get_distro_img, get_download_dir_path, get_my_deb_boxes,
+    get_my_rpm_boxes, get_rpm_distros, get_supported_terminals, get_supported_terminals_list,
     get_terminal_and_separator_arg, has_distrobox_installed, has_file_extension, has_host_access,
     has_podman_or_docker_installed, set_up_localisation,
 };
@@ -313,7 +313,7 @@ fn build_not_installed_status_page(title: &str, body: &str) -> adw::StatusPage {
 
 fn render_not_installed(scroll_area: &gtk::Box) {
     clear_children(scroll_area);
-  
+
     // TRANSLATORS: Error message shown when distrobox is not installed
     let title = gettext("Distrobox not found!");
     // TRANSLATORS: Error message shown when distrobox is not installed
@@ -371,6 +371,25 @@ fn load_boxes(scroll_area: &gtk::Box, window: &ApplicationWindow, active_page: O
     }
 }
 
+/// Loads the distro-colour CSS classes into the display, once. Doing this
+/// per box would pile up a provider for every tab of every rerender, and
+/// since every provider defined the same class, each new box repainted every
+/// existing bar with its own colour - the last box always won.
+fn ensure_distro_color_styles() {
+    static LOADED: std::sync::Once = std::sync::Once::new();
+    LOADED.call_once(|| {
+        if let Some(display) = gtk::gdk::Display::default() {
+            let provider = gtk::CssProvider::new();
+            provider.load_from_string(&get_distro_color_css());
+            gtk::style_context_add_provider_for_display(
+                &display,
+                &provider,
+                gtk::STYLE_PROVIDER_PRIORITY_APPLICATION,
+            );
+        }
+    });
+}
+
 fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::Box {
     let box_name = dbox.name.clone();
 
@@ -391,24 +410,11 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
     let badge_box = gtk::Box::new(Orientation::Horizontal, 6);
     badge_box.set_valign(Align::Center);
 
+    ensure_distro_color_styles();
     let color_bar = gtk::Box::new(Orientation::Vertical, 0);
     color_bar.set_size_request(4, 32);
     color_bar.add_css_class("distro-color-bar");
-    // Inline CSS provider so we do not need a separate stylesheet file.
-    // The colour comes from the same lookup table that fed the old
-    // Unicode dot, so the bar and the dot are guaranteed to agree.
-    let color_provider = gtk::CssProvider::new();
-    color_provider.load_from_data(&format!(
-        ".distro-color-bar {{ background-color: {}; border-radius: 2px; min-height: 32px; min-width: 4px; }}",
-        get_distro_color(&dbox.distro)
-    ));
-    if let Some(display) = gtk::gdk::Display::default() {
-        gtk::style_context_add_provider_for_display(
-            &display,
-            &color_provider,
-            gtk::STYLE_PROVIDER_PRIORITY_APPLICATION,
-        );
-    }
+    color_bar.add_css_class(&format!("distro-color-bar-{}", dbox.distro));
     badge_box.append(&color_bar);
 
     if let Some(icon_name) = get_distro_icon_name(&dbox.distro) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,11 +25,11 @@ use distrobox_handler::{
 
 mod utils;
 use utils::{
-    get_assemble_icon, get_cpu_and_mem_usage, get_deb_distros, get_distro_img,
-    get_download_dir_path, get_my_deb_boxes, get_my_rpm_boxes, get_rpm_distros,
-    get_supported_terminals, get_supported_terminals_list, get_terminal_and_separator_arg,
-    has_distrobox_installed, has_file_extension, has_host_access, has_podman_or_docker_installed,
-    set_up_localisation,
+    get_assemble_icon, get_cpu_and_mem_usage, get_deb_distros, get_distro_color,
+    get_distro_icon_name, get_distro_img, get_download_dir_path, get_my_deb_boxes, get_my_rpm_boxes,
+    get_rpm_distros, get_supported_terminals, get_supported_terminals_list,
+    get_terminal_and_separator_arg, has_distrobox_installed, has_file_extension, has_host_access,
+    has_podman_or_docker_installed, set_up_localisation,
 };
 const APP_ID: &str = "io.github.dvlv.boxbuddyrs";
 
@@ -383,8 +383,45 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
     tab_box.set_margin_end(10);
 
     //title
-    let page_img = gtk::Label::new(None);
-    page_img.set_markup(&get_distro_img(&dbox.distro));
+    // The header badge replaces the older Unicode-dot label with a real
+    // CSS-coloured bar (4 px wide, rounded) plus an optional distro logo
+    // if the icon theme happens to ship one. Falls back gracefully to
+    // either piece being absent - the bar is always rendered, the logo
+    // is best-effort.
+    let badge_box = gtk::Box::new(Orientation::Horizontal, 6);
+    badge_box.set_valign(Align::Center);
+
+    let color_bar = gtk::Box::new(Orientation::Vertical, 0);
+    color_bar.set_size_request(4, 32);
+    color_bar.add_css_class("distro-color-bar");
+    // Inline CSS provider so we do not need a separate stylesheet file.
+    // The colour comes from the same lookup table that fed the old
+    // Unicode dot, so the bar and the dot are guaranteed to agree.
+    let color_provider = gtk::CssProvider::new();
+    color_provider.load_from_data(&format!(
+        ".distro-color-bar {{ background-color: {}; border-radius: 2px; min-height: 32px; min-width: 4px; }}",
+        get_distro_color(&dbox.distro)
+    ));
+    if let Some(display) = gtk::gdk::Display::default() {
+        gtk::style_context_add_provider_for_display(
+            &display,
+            &color_provider,
+            gtk::STYLE_PROVIDER_PRIORITY_APPLICATION,
+        );
+    }
+    badge_box.append(&color_bar);
+
+    if let Some(icon_name) = get_distro_icon_name(&dbox.distro) {
+        let has_icon = gtk::gdk::Display::default()
+            .map(|d| gtk::IconTheme::for_display(&d).has_icon(icon_name))
+            .unwrap_or(false);
+        if has_icon {
+            let icon_img = gtk::Image::from_icon_name(icon_name);
+            icon_img.set_pixel_size(32);
+            badge_box.append(&icon_img);
+        }
+    }
+
     let page_title = gtk::Label::new(Some(&dbox.name));
     page_title.add_css_class("title-1");
 
@@ -405,7 +442,7 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
 
     let title_box = gtk::Box::new(Orientation::Horizontal, 10);
     title_box.set_margin_start(10);
-    title_box.append(&page_img);
+    title_box.append(&badge_box);
     title_box.append(&page_title);
     title_box.append(&page_status);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,6 @@ use adw::StyleManager;
 use gettextrs::{bind_textdomain_codeset, setlocale, textdomain, LocaleCategory};
 use gtk::gio::Settings;
 use gtk::prelude::SettingsExt;
-use std::collections::HashMap;
 use std::env;
 use std::path::Path;
 use std::process::Command;
@@ -122,40 +121,58 @@ pub fn has_file_extension(path: &str, extension: &str) -> bool {
         .map_or(false, |ext| ext.eq_ignore_ascii_case(extension))
 }
 
-/// Looks up the brand colour for a distribution, returning a CSS colour
-/// string (`#rrggbb`). Falls back to black for unknown distros. The
-/// lookup table is shared with `get_distro_img`; the dot unicode glyph
-/// that function emits is fine for the notebook tab, but a coloured
-/// bar in the box header needs a real CSS colour, not Pango markup.
-pub fn get_distro_color(distro: &str) -> &'static str {
-    let distro_colours: HashMap<&str, &str> = HashMap::from([
-        ("alma", "#dadada"),
-        ("alpine", "#2147ea"),
-        ("amazon", "#de5412"),
-        ("arch", "#12aaff"),
-        ("centos", "#ff6600"),
-        ("clearlinux", "#56bbff"),
-        ("crystal", "#8839ef"),
-        ("debian", "#da5555"),
-        ("deepin", "#0050ff"),
-        ("fedora", "#3b6db3"),
-        ("gentoo", "#daaada"),
-        ("kali", "#000000"),
-        ("mageia", "#b612b6"),
-        ("mint", "#6fbd20"),
-        ("neon", "#27ae60"),
-        ("opensuse", "#daff00"),
-        ("oracle", "#ff0000"),
-        ("redhat", "#ff6662"),
-        ("rhel", "#ff6662"),
-        ("rocky", "#91ff91"),
-        ("slackware", "#6145a7"),
-        ("ubuntu", "#FF4400"),
-        ("vanilla", "#7f11e0"),
-        ("void", "#abff12"),
-    ]);
+/// Distro brand colours, shared by the coloured dot on the notebook tab and
+/// the coloured bar in the box header, so the two can never disagree.
+const DISTRO_COLOURS: [(&str, &str); 24] = [
+    ("alma", "#dadada"),
+    ("alpine", "#2147ea"),
+    ("amazon", "#de5412"),
+    ("arch", "#12aaff"),
+    ("centos", "#ff6600"),
+    ("clearlinux", "#56bbff"),
+    ("crystal", "#8839ef"),
+    ("debian", "#da5555"),
+    ("deepin", "#0050ff"),
+    ("fedora", "#3b6db3"),
+    ("gentoo", "#daaada"),
+    ("kali", "#000000"),
+    ("mageia", "#b612b6"),
+    ("mint", "#6fbd20"),
+    ("neon", "#27ae60"),
+    ("opensuse", "#daff00"),
+    ("oracle", "#ff0000"),
+    ("redhat", "#ff6662"),
+    ("rhel", "#ff6662"),
+    ("rocky", "#91ff91"),
+    ("slackware", "#6145a7"),
+    ("ubuntu", "#FF4400"),
+    ("vanilla", "#7f11e0"),
+    ("void", "#abff12"),
+];
 
-    distro_colours.get(distro).copied().unwrap_or("#000000")
+/// Looks up the brand colour for a distribution, returning a CSS colour
+/// string (`#rrggbb`). Falls back to black for unknown distros.
+pub fn get_distro_color(distro: &str) -> &'static str {
+    DISTRO_COLOURS
+        .iter()
+        .find(|(name, _)| *name == distro)
+        .map_or("#000000", |(_, colour)| colour)
+}
+
+/// CSS for the coloured bar in each box header: a base class plus one
+/// `.distro-color-bar-<name>` override per known distro, generated from the
+/// same table as the tab dot. Meant to be loaded into the display once, not
+/// per box.
+pub fn get_distro_color_css() -> String {
+    let mut css = String::from(
+        ".distro-color-bar { background-color: #000000; border-radius: 2px; min-height: 32px; min-width: 4px; }\n",
+    );
+    for (name, colour) in DISTRO_COLOURS {
+        css.push_str(&format!(
+            ".distro-color-bar-{name} {{ background-color: {colour}; }}\n"
+        ));
+    }
+    css
 }
 
 /// Maps a distribution short name to a freedesktop icon name we know the
@@ -184,38 +201,10 @@ pub fn get_distro_icon_name(distro: &str) -> Option<&'static str> {
 
 /// Gets the unicode dot character coloured with a colour similar to the distro's branding
 pub fn get_distro_img(distro: &str) -> String {
-    let distro_colours: HashMap<&str, &str> = HashMap::from([
-        ("alma", "#dadada"),
-        ("alpine", "#2147ea"),
-        ("amazon", "#de5412"),
-        ("arch", "#12aaff"),
-        ("centos", "#ff6600"),
-        ("clearlinux", "#56bbff"),
-        ("crystal", "#8839ef"),
-        ("debian", "#da5555"),
-        ("deepin", "#0050ff"),
-        ("fedora", "#3b6db3"),
-        ("gentoo", "#daaada"),
-        ("kali", "#000000"),
-        ("mageia", "#b612b6"),
-        ("mint", "#6fbd20"),
-        ("neon", "#27ae60"),
-        ("opensuse", "#daff00"),
-        ("oracle", "#ff0000"),
-        ("redhat", "#ff6662"),
-        ("rhel", "#ff6662"),
-        ("rocky", "#91ff91"),
-        ("slackware", "#6145a7"),
-        ("ubuntu", "#FF4400"),
-        ("vanilla", "#7f11e0"),
-        ("void", "#abff12"),
-    ]);
-
-    if distro_colours.contains_key(distro) {
-        return format!("<span foreground=\"{}\">⬤</span>", distro_colours[distro]);
-    }
-
-    format!("<span foreground=\"{}\">⬤</span>", "#000000")
+    format!(
+        "<span foreground=\"{}\">\u{2b24}</span>",
+        get_distro_color(distro)
+    )
 }
 
 /// Returns a vector of distros which can install .deb packages

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -122,6 +122,66 @@ pub fn has_file_extension(path: &str, extension: &str) -> bool {
         .map_or(false, |ext| ext.eq_ignore_ascii_case(extension))
 }
 
+/// Looks up the brand colour for a distribution, returning a CSS colour
+/// string (`#rrggbb`). Falls back to black for unknown distros. The
+/// lookup table is shared with `get_distro_img`; the dot unicode glyph
+/// that function emits is fine for the notebook tab, but a coloured
+/// bar in the box header needs a real CSS colour, not Pango markup.
+pub fn get_distro_color(distro: &str) -> &'static str {
+    let distro_colours: HashMap<&str, &str> = HashMap::from([
+        ("alma", "#dadada"),
+        ("alpine", "#2147ea"),
+        ("amazon", "#de5412"),
+        ("arch", "#12aaff"),
+        ("centos", "#ff6600"),
+        ("clearlinux", "#56bbff"),
+        ("crystal", "#8839ef"),
+        ("debian", "#da5555"),
+        ("deepin", "#0050ff"),
+        ("fedora", "#3b6db3"),
+        ("gentoo", "#daaada"),
+        ("kali", "#000000"),
+        ("mageia", "#b612b6"),
+        ("mint", "#6fbd20"),
+        ("neon", "#27ae60"),
+        ("opensuse", "#daff00"),
+        ("oracle", "#ff0000"),
+        ("redhat", "#ff6662"),
+        ("rhel", "#ff6662"),
+        ("rocky", "#91ff91"),
+        ("slackware", "#6145a7"),
+        ("ubuntu", "#FF4400"),
+        ("vanilla", "#7f11e0"),
+        ("void", "#abff12"),
+    ]);
+
+    distro_colours.get(distro).copied().unwrap_or("#000000")
+}
+
+/// Maps a distribution short name to a freedesktop icon name we know the
+/// icon theme is likely to ship. Returns `None` for distros we do not
+/// have a logo for, so the caller can fall back to a plain coloured bar.
+pub fn get_distro_icon_name(distro: &str) -> Option<&'static str> {
+    match distro {
+        "ubuntu" => Some("ubuntu-logo"),
+        "debian" => Some("debian-logo"),
+        "fedora" => Some("fedora-logo"),
+        "arch" => Some("archlinux-logo"),
+        "opensuse" => Some("opensuse-logo"),
+        "manjaro" => Some("manjaro-logo"),
+        "mint" => Some("linuxmint-logo"),
+        "alpine" => Some("alpine-logo"),
+        "centos" => Some("centos-logo"),
+        "rhel" => Some("rhel-logo"),
+        "rocky" => Some("rocky-logo"),
+        "alma" => Some("almalinux-logo"),
+        "void" => Some("void-logo"),
+        "gentoo" => Some("gentoo-logo"),
+        "kali" => Some("kali-logo"),
+        _ => None,
+    }
+}
+
 /// Gets the unicode dot character coloured with a colour similar to the distro's branding
 pub fn get_distro_img(distro: &str) -> String {
     let distro_colours: HashMap<&str, &str> = HashMap::from([


### PR DESCRIPTION
Closes #201

Replaces the Unicode dot in the box header with a CSS-coloured bar, plus the distro's logo when the icon theme has one — logos are strictly best-effort, guarded by `has_icon`, so a theme without them just shows the bar, and an unknown distro falls back to a black bar. The tab strip keeps its dot.

Both markers draw from one colour table now (`DISTRO_COLOURS` in utils), so they can't drift apart, and `get_distro_img` shrank to a one-liner in the process.

One implementation note worth calling out for review: the bar's CSS is loaded into the display once, behind a `std::sync::Once`, with a class per distro. My first version registered a provider per box, and since every provider defined the same class, whichever box rendered last repainted every bar with its own colour — a Fedora box came out Ubuntu orange. If you ever want more per-distro styling, the generated-classes approach extends naturally.

Screenshot (stub `distrobox list` output, Fedora box focused — blue bar, logo found by the theme):

![coloured bar and logo](https://raw.githubusercontent.com/kacperpaczos/BoxBuddyRS/issue-assets/issue-assets/boxbuddy-distro-badge.png)

### Testing

Verified against a stub `distrobox` emitting one Fedora and one Ubuntu box: the focused Fedora tab shows the Fedora-blue bar (the last-provider bug used to turn it orange in exactly this setup). Warning, clippy and `cargo fmt --check` results are identical to master.
