### PR TITLE
Add Start and Reboot actions for stopped boxes

### DIFF
--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    get_command_output, get_host_desktop_files, get_repository_list,
+    get_command_output, get_container_runtime, get_host_desktop_files, get_repository_list,
     get_terminal_and_separator_arg, is_flatpak, is_nvidia, run_command,
 };
 use std::process::Command;
@@ -526,13 +526,13 @@ pub fn stop_box(box_name: &str) {
     let _ = run_command("distrobox", Some(&["stop", box_name, "--yes"]));
 }
 
-/// Starts a stopped container via the underlying container engine
-/// (`podman start`). `distrobox start` would also work, but it shells
-/// out to podman/docker itself, and calling it directly avoids one
-/// extra layer of subprocess when all we want is to bring the
-/// container back up.
+/// Starts a stopped container via the underlying container engine.
+/// `distrobox start` does not exist; entering the box would start it too,
+/// but that spawns a shell we would immediately have to throw away, so
+/// asking the runtime directly is the quiet way to bring it back up.
 pub fn start_box(box_name: &str) {
-    let _ = run_command("podman", Some(&["start", box_name]));
+    let runtime = get_container_runtime();
+    let _ = run_command(&runtime, Some(&["start", box_name]));
 }
 
 /// Stops and then starts the box again so the user picks up any image
@@ -540,7 +540,8 @@ pub fn start_box(box_name: &str) {
 /// can see the output.
 pub fn reboot_box(box_name: &str) {
     let (term, sep, term_is_flatpak) = get_terminal_and_separator_arg();
-    let command = format!("distrobox-stop {box_name} -Y; podman start {box_name}");
+    let runtime = get_container_runtime();
+    let command = format!("distrobox stop {box_name} --yes; {runtime} start {box_name}");
 
     if is_flatpak() {
         if term_is_flatpak {

--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -526,6 +526,69 @@ pub fn stop_box(box_name: &str) {
     let _ = run_command("distrobox", Some(&["stop", box_name, "--yes"]));
 }
 
+/// Starts a stopped container via the underlying container engine
+/// (`podman start`). `distrobox start` would also work, but it shells
+/// out to podman/docker itself, and calling it directly avoids one
+/// extra layer of subprocess when all we want is to bring the
+/// container back up.
+pub fn start_box(box_name: &str) {
+    let _ = run_command("podman", Some(&["start", box_name]));
+}
+
+/// Stops and then starts the box again so the user picks up any image
+/// updates or in-box service restarts. Runs in a terminal so the user
+/// can see the output.
+pub fn reboot_box(box_name: &str) {
+    let (term, sep, term_is_flatpak) = get_terminal_and_separator_arg();
+    let command = format!("distrobox-stop {box_name} -Y; podman start {box_name}");
+
+    if is_flatpak() {
+        if term_is_flatpak {
+            Command::new("flatpak-spawn")
+                .arg("--host")
+                .arg("flatpak")
+                .arg("run")
+                .arg(term)
+                .arg(sep)
+                .arg("bash")
+                .arg("-c")
+                .arg(&command)
+                .spawn()
+                .unwrap();
+        } else {
+            Command::new("flatpak-spawn")
+                .arg("--host")
+                .arg(term)
+                .arg(sep)
+                .arg("bash")
+                .arg("-c")
+                .arg(&command)
+                .spawn()
+                .unwrap();
+        }
+    } else {
+        if term_is_flatpak {
+            Command::new("flatpak")
+                .arg("run")
+                .arg(term)
+                .arg(sep)
+                .arg("bash")
+                .arg("-c")
+                .arg(&command)
+                .spawn()
+                .unwrap();
+        } else {
+            Command::new(term)
+                .arg(sep)
+                .arg("bash")
+                .arg("-c")
+                .arg(&command)
+                .spawn()
+                .unwrap();
+        }
+    }
+}
+
 /// Gets count of boxes, used to move the active page on the Notebook to the newest
 /// box after creation.
 pub fn get_number_of_boxes() -> u32 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,11 +16,11 @@ use gtk::{
 
 mod distrobox_handler;
 use distrobox_handler::{
-assemble_box, clone_box, create_box, delete_box, export_app_from_box, get_all_distroboxes,
+    assemble_box, clone_box, create_box, delete_box, export_app_from_box, get_all_distroboxes,
     get_apps_in_box, get_available_images_with_distro_name, get_binaries_exported_from_box,
-    get_number_of_boxes, install_deb_in_box, install_rpm_in_box, open_terminal_in_box,
-    reboot_box, remove_app_from_host, remove_exported_binary_from_box, run_command_in_box,
-    start_box, stop_box, upgrade_all_boxes, upgrade_box, DBox, DBoxApp,
+    get_number_of_boxes, install_deb_in_box, install_rpm_in_box, open_terminal_in_box, reboot_box,
+    remove_app_from_host, remove_exported_binary_from_box, run_command_in_box, start_box, stop_box,
+    upgrade_all_boxes, upgrade_box, DBox, DBoxApp,
 };
 
 mod utils;
@@ -313,7 +313,7 @@ fn build_not_installed_status_page(title: &str, body: &str) -> adw::StatusPage {
 
 fn render_not_installed(scroll_area: &gtk::Box) {
     clear_children(scroll_area);
-  
+
     // TRANSLATORS: Error message shown when distrobox is not installed
     let title = gettext("Distrobox not found!");
     // TRANSLATORS: Error message shown when distrobox is not installed
@@ -406,7 +406,7 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
     // Start button is the visible counterpart of Stop - it makes sense to
     // add the row right next to Stop so the titlebar keeps a single
     // trailing button.
-    let start_btn = gtk::Button::from_icon_name("media-playback-start");
+    let start_btn = gtk::Button::from_icon_name("media-playback-start-symbolic");
     // TRANSLATORS: Button tooltip
     start_btn.set_tooltip_text(Some(&gettext("Start Box")));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,11 +16,11 @@ use gtk::{
 
 mod distrobox_handler;
 use distrobox_handler::{
-    assemble_box, clone_box, create_box, delete_box, export_app_from_box, get_all_distroboxes,
+assemble_box, clone_box, create_box, delete_box, export_app_from_box, get_all_distroboxes,
     get_apps_in_box, get_available_images_with_distro_name, get_binaries_exported_from_box,
     get_number_of_boxes, install_deb_in_box, install_rpm_in_box, open_terminal_in_box,
-    remove_app_from_host, remove_exported_binary_from_box, run_command_in_box, stop_box,
-    upgrade_all_boxes, upgrade_box, DBox, DBoxApp,
+    reboot_box, remove_app_from_host, remove_exported_binary_from_box, run_command_in_box,
+    start_box, stop_box, upgrade_all_boxes, upgrade_box, DBox, DBoxApp,
 };
 
 mod utils;
@@ -403,6 +403,20 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
         delayed_rerender(&win_clone, Some(tab_num));
     });
 
+    // Start button is the visible counterpart of Stop - it makes sense to
+    // add the row right next to Stop so the titlebar keeps a single
+    // trailing button.
+    let start_btn = gtk::Button::from_icon_name("media-playback-start");
+    // TRANSLATORS: Button tooltip
+    start_btn.set_tooltip_text(Some(&gettext("Start Box")));
+
+    let start_bn_clone = dbox.name.clone();
+    let start_win_clone = window.clone();
+    start_btn.connect_clicked(move |_btn| {
+        start_box(&start_bn_clone);
+        delayed_rerender(&start_win_clone, Some(tab_num));
+    });
+
     let title_box = gtk::Box::new(Orientation::Horizontal, 10);
     title_box.set_margin_start(10);
     title_box.append(&page_img);
@@ -411,6 +425,8 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
 
     if dbox.is_running {
         title_box.append(&stop_btn);
+    } else {
+        title_box.append(&start_btn);
     }
 
     // list view
@@ -442,6 +458,18 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
 
     let up_bn_clone = box_name.clone();
     upgrade_row.connect_activated(move |_row| on_upgrade_clicked(&up_bn_clone));
+
+    // Reboot Box Icon
+    let reboot_icon = gtk::Image::from_icon_name("system-reboot-symbolic");
+
+    let reboot_row = ActionRow::new();
+    // TRANSLATORS: Row Label
+    reboot_row.set_title(&gettext("Reboot Box"));
+    reboot_row.add_suffix(&reboot_icon);
+    reboot_row.set_activatable(true);
+
+    let reboot_bn_clone = box_name.clone();
+    reboot_row.connect_activated(move |_row| on_reboot_clicked(&reboot_bn_clone));
 
     // Show Applications Icon
     let show_applications_icon = gtk::Image::from_icon_name("application-x-executable-symbolic");
@@ -495,6 +523,7 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
     // put all into list
     boxed_list.append(&open_terminal_row);
     boxed_list.append(&upgrade_row);
+    boxed_list.append(&reboot_row);
     boxed_list.append(&show_applications_row);
 
     // Make deb / rpm row if applicable
@@ -997,6 +1026,10 @@ fn on_open_terminal_clicked(box_name: String) {
 
 fn on_upgrade_clicked(box_name: &str) {
     upgrade_box(box_name);
+}
+
+fn on_reboot_clicked(box_name: &str) {
+    reboot_box(box_name);
 }
 
 fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {


### PR DESCRIPTION
Closes #202

Adds the counterpart to the Stop button: when a box isn't running, a Start button (standard `media-playback-start-symbolic`) appears in the same spot in the header and brings it back through the container runtime — the same podman/docker detection the rest of the app uses, no throwaway shell. There's also a Reboot Box row in the actions list: stop and start in one go, run in a terminal so the output is visible, which is handy right after upgrading a box.

![start button on a stopped box](https://raw.githubusercontent.com/kacperpaczos/BoxBuddyRS/issue-assets/issue-assets/boxbuddy-start-button.png)

Two choices worth a reviewer's eye. Start asks the runtime directly (`podman start` / `docker start`) rather than entering the box, because `distrobox start` doesn't exist and entering spawns a shell that would have to be thrown away. And the reboot uses the `distrobox stop` subcommand rather than the split `distrobox-stop` binary, since v2 no longer installs the split form — the subcommand works on both, and matches what `stop_box` already does.

### Testing

The exact command sequences were run against a real box: `distrobox stop <box> --yes; podman start <box>` returns it to `Up`, and the runtime-detected start alone does the same from a stopped state. The button rendering is screenshotted above. What I couldn't do here is click the button itself in a live session — the wiring mirrors the existing Stop button line for line, but a click-through before merging wouldn't hurt.
