### PR TITLE
Stop crashing when launched with a file that has no usable path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -136,12 +136,20 @@ fn build_ui_as_open(app: &Application, files: &[gio::File], _hint: &str) {
     let window = make_window(app);
 
     if !files.is_empty() {
-        // BoxBuddy will only support opening one file at a time for now
-
-        // TODO I dont like all this unwrapping
-        let first_file = files.first().unwrap();
-        let file_path = first_file.path().unwrap();
-        let file_path_str = file_path.to_str().unwrap();
+        // BoxBuddy will only support opening one file at a time for now.
+        // Bail out silently if anything is missing: an empty gio::File, a path
+        // the host cannot represent, or a non-UTF-8 path. Falling through
+        // here just means the user launched BoxBuddy without a usable file,
+        // which is a normal startup; there is no error to surface.
+        let Some(first_file) = files.first() else {
+            return;
+        };
+        let Some(file_path) = first_file.path() else {
+            return;
+        };
+        let Some(file_path_str) = file_path.to_str() else {
+            return;
+        };
 
         if has_file_extension(file_path_str, "rpm") {
             show_install_binary_popup(&window, file_path_str, BinaryPackageType::Rpm);


### PR DESCRIPTION
Closes #203

Replaces the unwrap chain in `build_ui_as_open` — the one the `// TODO I dont like all this unwrapping` comment was pointing at — with let-else early returns. A file that has no local path (a URL) or a non-UTF-8 path now just means there's nothing to open, and BoxBuddy starts as if launched plain, instead of aborting before the window appears.

### Testing

On master, `boxbuddy-rs https://example.com/pkg.rpm` panics at `src/main.rs:143` (`Option::unwrap()` on `None`) and dies with SIGABRT. With this change the same invocation opens the window normally. A plain launch and a launch with an `.rpm` argument behave as before.
