### PR TITLE
Detect the package manager from the box image (with the first unit tests)

### DIFF
--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -544,9 +544,11 @@ pub fn get_number_of_boxes() -> u32 {
     count
 }
 
-/// Tries to install a .deb file in the box using `apt`. Spawns a terminal for
-/// the user to confirm / cancel.
-pub fn install_deb_in_box(box_name: String, file_path: String) {
+/// Runs the `distrobox enter NAME -- sudo <manager> install PATH` command
+/// in a terminal so the user can confirm the `sudo` prompt. Used by both
+/// the `.deb` and `.rpm` install paths - the only thing that varies is
+/// which package manager we ask for.
+fn run_install_in_terminal(box_name: &str, file_path: &str, manager: &str) {
     let (term, sep, term_is_flatpak) = get_terminal_and_separator_arg();
 
     if is_flatpak() {
@@ -562,7 +564,7 @@ pub fn install_deb_in_box(box_name: String, file_path: String) {
                 .arg(box_name)
                 .arg("--")
                 .arg("sudo")
-                .arg("apt")
+                .arg(manager)
                 .arg("install")
                 .arg(file_path)
                 .spawn()
@@ -577,124 +579,73 @@ pub fn install_deb_in_box(box_name: String, file_path: String) {
                 .arg(box_name)
                 .arg("--")
                 .arg("sudo")
-                .arg("apt")
+                .arg(manager)
                 .arg("install")
                 .arg(file_path)
                 .spawn()
                 .unwrap();
         }
+    } else if term_is_flatpak {
+        Command::new("flatpak")
+            .arg("run")
+            .arg(term)
+            .arg(sep)
+            .arg("distrobox")
+            .arg("enter")
+            .arg(box_name)
+            .arg("--")
+            .arg("sudo")
+            .arg(manager)
+            .arg("install")
+            .arg(file_path)
+            .spawn()
+            .unwrap();
     } else {
-        if term_is_flatpak {
-            Command::new("flatpak")
-                .arg("run")
-                .arg(term)
-                .arg(sep)
-                .arg("distrobox")
-                .arg("enter")
-                .arg(box_name)
-                .arg("--")
-                .arg("sudo")
-                .arg("apt")
-                .arg("install")
-                .arg(file_path)
-                .spawn()
-                .unwrap();
-        } else {
-            Command::new(term)
-                .arg(sep)
-                .arg("distrobox")
-                .arg("enter")
-                .arg(box_name)
-                .arg("--")
-                .arg("sudo")
-                .arg("apt")
-                .arg("install")
-                .arg(file_path)
-                .spawn()
-                .unwrap();
-        }
+        Command::new(term)
+            .arg(sep)
+            .arg("distrobox")
+            .arg("enter")
+            .arg(box_name)
+            .arg("--")
+            .arg("sudo")
+            .arg(manager)
+            .arg("install")
+            .arg(file_path)
+            .spawn()
+            .unwrap();
     }
 }
 
-/// Tries to install a .rpm file in the box using `zypper` or `dnf`.
-/// Spawns a terminal for the user to confirm / cancel.
-pub fn install_rpm_in_box(box_name: String, file_path: String) {
-    let (term, sep, term_is_flatpak) = get_terminal_and_separator_arg();
+/// Tries to install a .deb file in the box using the package manager we
+/// infer from the box's image. Falls back to `apt` for unknown images
+/// because most deb-shaped distros in distrobox's supported list do use
+/// it; the user gets a visible error in the terminal if that guess is
+/// wrong.
+pub fn install_deb_in_box(box_name: String, image: String, file_path: String) {
+    let manager = match crate::utils::detect_pkg_manager(&image) {
+        Some(crate::utils::PkgManager::Apt) => "apt",
+        // .deb is not the native package format for non-apt distros;
+        // refusing here would be safer than producing an apt-only error,
+        // but the old behaviour was to always try apt, so we keep that
+        // as a safe default and surface the failure in the terminal
+        // where the user can read it.
+        _ => "apt",
+    };
+    run_install_in_terminal(&box_name, &file_path, manager);
+}
 
-    //TODO this needs to be done when fetching boxes at the beginning
-    let mut pkg_man = String::from("dnf");
-    let my_boxes = get_all_distroboxes();
-    for dbox in my_boxes {
-        if dbox.name == box_name && dbox.distro == "opensuse" {
-            pkg_man = String::from("zypper");
-        }
-    }
-
-    if is_flatpak() {
-        if term_is_flatpak {
-            Command::new("flatpak-spawn")
-                .arg("--host")
-                .arg("flatpak")
-                .arg("run")
-                .arg(term)
-                .arg(sep)
-                .arg("distrobox")
-                .arg("enter")
-                .arg(box_name)
-                .arg("--")
-                .arg("sudo")
-                .arg(pkg_man)
-                .arg("install")
-                .arg(file_path)
-                .spawn()
-                .unwrap();
-        } else {
-            Command::new("flatpak-spawn")
-                .arg("--host")
-                .arg(term)
-                .arg(sep)
-                .arg("distrobox")
-                .arg("enter")
-                .arg(box_name)
-                .arg("--")
-                .arg("sudo")
-                .arg(pkg_man)
-                .arg("install")
-                .arg(file_path)
-                .spawn()
-                .unwrap();
-        }
-    } else {
-        if term_is_flatpak {
-            Command::new("flatpak")
-                .arg("run")
-                .arg(term)
-                .arg(sep)
-                .arg("distrobox")
-                .arg("enter")
-                .arg(box_name)
-                .arg("--")
-                .arg("sudo")
-                .arg(pkg_man)
-                .arg("install")
-                .arg(file_path)
-                .spawn()
-                .unwrap();
-        } else {
-            Command::new(term)
-                .arg(sep)
-                .arg("distrobox")
-                .arg("enter")
-                .arg(box_name)
-                .arg("--")
-                .arg("sudo")
-                .arg(pkg_man)
-                .arg("install")
-                .arg(file_path)
-                .spawn()
-                .unwrap();
-        }
-    }
+/// Tries to install a .rpm file in the box using the package manager we
+/// infer from the box's image. Detects both `dnf` (Fedora / RHEL clones)
+/// and `zypper` (openSUSE) and falls back to `dnf` for unknown images.
+/// Like the `.deb` path, the actual command runs in a terminal so the
+/// user can confirm the `sudo` prompt.
+pub fn install_rpm_in_box(box_name: String, image: String, file_path: String) {
+    let manager = match crate::utils::detect_pkg_manager(&image) {
+        Some(crate::utils::PkgManager::Zypper) => "zypper",
+        Some(crate::utils::PkgManager::Dnf) => "dnf",
+        _ => "dnf",
+    };
+    run_install_in_terminal(&box_name, &file_path, manager);
 }
 
 pub fn clone_box(box_to_clone: &str, new_name: &str) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,7 +313,7 @@ fn build_not_installed_status_page(title: &str, body: &str) -> adw::StatusPage {
 
 fn render_not_installed(scroll_area: &gtk::Box) {
     clear_children(scroll_area);
-  
+
     // TRANSLATORS: Error message shown when distrobox is not installed
     let title = gettext("Distrobox not found!");
     // TRANSLATORS: Error message shown when distrobox is not installed

--- a/src/main.rs
+++ b/src/main.rs
@@ -509,8 +509,9 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
         binary_row.set_activatable(true);
 
         let win_clone = window.clone();
+        let deb_img_clone = dbox.image_url.clone();
         binary_row.connect_activated(move |_row| {
-            on_install_deb_clicked(&win_clone, deb_bn_clone.clone());
+            on_install_deb_clicked(&win_clone, deb_bn_clone.clone(), deb_img_clone.clone());
         });
 
         boxed_list.append(&binary_row);
@@ -521,8 +522,9 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
         binary_row.set_activatable(true);
 
         let win_clone = window.clone();
+        let rpm_img_clone = dbox.image_url.clone();
         binary_row.connect_activated(move |_row| {
-            on_install_rpm_clicked(&win_clone, rpm_bn_clone.clone());
+            on_install_rpm_clicked(&win_clone, rpm_bn_clone.clone(), rpm_img_clone.clone());
         });
 
         boxed_list.append(&binary_row);
@@ -1570,9 +1572,18 @@ fn show_install_binary_popup(
             .to_string();
 
         if !box_name.is_empty() && !bin_clone.is_empty() {
+            // Look up the box's image so the right package manager is
+            // picked. Done per-click rather than cached because the image
+            // can change after a `distrobox upgrade`.
+            let image = get_all_distroboxes()
+                .into_iter()
+                .find(|b| b.name == box_name)
+                .map(|b| b.image_url)
+                .unwrap_or_default();
+
             match pt_clone {
-                BinaryPackageType::Deb => install_deb_in_box(box_name, bin_clone.clone()),
-                BinaryPackageType::Rpm => install_rpm_in_box(box_name, bin_clone.clone()),
+                BinaryPackageType::Deb => install_deb_in_box(box_name, image, bin_clone.clone()),
+                BinaryPackageType::Rpm => install_rpm_in_box(box_name, image, bin_clone.clone()),
             }
             popup_clone.destroy();
         }
@@ -1586,7 +1597,7 @@ fn show_install_binary_popup(
     install_binary_popup.present();
 }
 
-fn on_install_deb_clicked(window: &ApplicationWindow, box_name: String) {
+fn on_install_deb_clicked(window: &ApplicationWindow, box_name: String, box_image: String) {
     let deb_filter = gtk::FileFilter::new();
 
     //TRANSLATORS: File type
@@ -1613,7 +1624,7 @@ fn on_install_deb_clicked(window: &ApplicationWindow, box_name: String) {
                     } else if !has_file_extension(&dp, "deb") {
                         show_incorrect_binary_file_popup(&window, BinaryPackageType::Deb);
                     } else {
-                        install_deb_in_box(box_name, dp);
+                        install_deb_in_box(box_name, box_image, dp);
                     }
                 }
             }
@@ -1621,7 +1632,7 @@ fn on_install_deb_clicked(window: &ApplicationWindow, box_name: String) {
     );
 }
 
-fn on_install_rpm_clicked(window: &ApplicationWindow, box_name: String) {
+fn on_install_rpm_clicked(window: &ApplicationWindow, box_name: String, box_image: String) {
     let rpm_filter = gtk::FileFilter::new();
 
     //TRANSLATORS: File type
@@ -1648,7 +1659,7 @@ fn on_install_rpm_clicked(window: &ApplicationWindow, box_name: String) {
                     } else if !has_file_extension(&rp, "rpm") {
                         show_incorrect_binary_file_popup(&window, BinaryPackageType::Rpm);
                     } else {
-                        install_rpm_in_box(box_name, rp);
+                        install_rpm_in_box(box_name, box_image, rp);
                     }
                 }
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -260,10 +260,7 @@ pub fn detect_pkg_manager(image: &str) -> Option<PkgManager> {
         || lower.contains("neon")
     {
         Some(PkgManager::Apt)
-    } else if lower.contains("opensuse")
-        || lower.contains("tumbleweed")
-        || lower.contains("leap")
-    {
+    } else if lower.contains("opensuse") || lower.contains("tumbleweed") || lower.contains("leap") {
         Some(PkgManager::Zypper)
     } else if lower.contains("arch")
         || lower.contains("blackarch")
@@ -808,4 +805,83 @@ pub fn get_download_dir_path() -> String {
         let hme = home_dir.unwrap();
         format!("{hme}/Downloads")
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{detect_pkg_manager, PkgManager};
+
+    /// Every image URL here is one distrobox actually offers in
+    /// `distrobox create --compatibility`, plus the docker.io shorthands
+    /// people type by hand.
+    #[test]
+    fn detects_manager_for_real_image_urls() {
+        let cases = [
+            ("docker.io/library/ubuntu:latest", PkgManager::Apt),
+            ("quay.io/toolbx/ubuntu-toolbox:24.04", PkgManager::Apt),
+            ("docker.io/library/debian:12", PkgManager::Apt),
+            ("docker.io/kalilinux/kali-rolling", PkgManager::Apt),
+            ("linuxmintd/mint21.3-amd64", PkgManager::Apt),
+            ("quay.io/fedora/fedora:43", PkgManager::Dnf),
+            (
+                "registry.fedoraproject.org/fedora-toolbox:latest",
+                PkgManager::Dnf,
+            ),
+            ("ghcr.io/ublue-os/bluefin-cli", PkgManager::Dnf),
+            ("quay.io/centos/centos:stream9", PkgManager::Dnf),
+            ("registry.access.redhat.com/ubi9/ubi", PkgManager::Dnf),
+            ("quay.io/rockylinux/rockylinux:9", PkgManager::Dnf),
+            ("docker.io/library/almalinux:9", PkgManager::Dnf),
+            (
+                "public.ecr.aws/amazonlinux/amazonlinux:2023",
+                PkgManager::Dnf,
+            ),
+            (
+                "container-registry.oracle.com/os/oraclelinux:9",
+                PkgManager::Dnf,
+            ),
+            (
+                "registry.opensuse.org/opensuse/tumbleweed:latest",
+                PkgManager::Zypper,
+            ),
+            (
+                "registry.opensuse.org/opensuse/leap:15.6",
+                PkgManager::Zypper,
+            ),
+            ("docker.io/library/archlinux:latest", PkgManager::Pacman),
+            (
+                "docker.io/blackarchlinux/blackarch:latest",
+                PkgManager::Pacman,
+            ),
+            ("docker.io/library/alpine:3.20", PkgManager::Apk),
+            ("cgr.dev/chainguard/wolfi-base", PkgManager::Apk),
+            ("ghcr.io/void-linux/void-glibc:latest", PkgManager::Xbps),
+            ("docker.io/gentoo/stage3:latest", PkgManager::Emerge),
+            ("docker.io/vbatts/slackware:current", PkgManager::Installpkg),
+        ];
+
+        for (image, expected) in cases {
+            assert_eq!(
+                detect_pkg_manager(image),
+                Some(expected),
+                "wrong manager for {image}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_images_detect_nothing() {
+        assert_eq!(detect_pkg_manager("docker.io/library/hello-world"), None);
+        assert_eq!(detect_pkg_manager(""), None);
+    }
+
+    /// The match is case-insensitive, since registries are but tags are not
+    /// always typed that way.
+    #[test]
+    fn detection_ignores_case() {
+        assert_eq!(
+            detect_pkg_manager("docker.io/library/Ubuntu:LATEST"),
+            Some(PkgManager::Apt)
+        );
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -216,6 +216,86 @@ pub fn get_my_rpm_boxes() -> Vec<String> {
     my_rpm_boxes
 }
 
+/// The package manager of a given container image. Detected by matching the
+/// image name (e.g. `docker.io/library/archlinux:latest`) against the same
+/// set of regexes Kontainer uses - see
+/// `packageinstallcommand.cpp:16-50` upstream. We deliberately avoid pulling
+/// in a regex crate: `str::contains` with a few alternatives per line is
+/// enough for the shapes distrobox upstream ships today, and it keeps the
+/// dep graph clean.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PkgManager {
+    Apt,
+    Dnf,
+    Zypper,
+    Pacman,
+    Apk,
+    Xbps,
+    Emerge,
+    Installpkg,
+}
+
+/// Detects the package manager used inside a container by inspecting its
+/// image name. Returns `None` for images that do not match any of the
+/// patterns - the caller is then responsible for falling back to a safe
+/// default or refusing the operation outright.
+pub fn detect_pkg_manager(image: &str) -> Option<PkgManager> {
+    let lower = image.to_lowercase();
+    // Order matters only in the sense that more specific matches come
+    // first. All distros within one family share a manager, so the order
+    // between families does not.
+    if lower.contains("fedora")
+        || lower.contains("bluefin")
+        || lower.contains("ublue-os/fedora")
+        || lower.contains("fedoraproject.org/fedora")
+    {
+        Some(PkgManager::Dnf)
+    } else if lower.contains("ubuntu")
+        || lower.contains("toolbx/ubuntu")
+        || lower.contains("ubuntu-toolbox")
+        || lower.contains("debian")
+        || lower.contains("neurodebian")
+        || lower.contains("mint")
+        || lower.contains("kali")
+        || lower.contains("neon")
+    {
+        Some(PkgManager::Apt)
+    } else if lower.contains("opensuse")
+        || lower.contains("tumbleweed")
+        || lower.contains("leap")
+    {
+        Some(PkgManager::Zypper)
+    } else if lower.contains("arch")
+        || lower.contains("blackarch")
+        || lower.contains("ublue-os/arch")
+        || lower.contains("bazzite-arch")
+        || lower.contains("arch-toolbox")
+    {
+        Some(PkgManager::Pacman)
+    } else if lower.contains("centos")
+        || lower.contains("rhel")
+        || lower.contains("rocky")
+        || lower.contains("alma")
+        || lower.contains("ubi")
+        || lower.contains("amazonlinux")
+        || lower.contains("oracle")
+    {
+        Some(PkgManager::Dnf)
+    } else if lower.contains("alpine") {
+        Some(PkgManager::Apk)
+    } else if lower.contains("void") {
+        Some(PkgManager::Xbps)
+    } else if lower.contains("gentoo") {
+        Some(PkgManager::Emerge)
+    } else if lower.contains("slack") {
+        Some(PkgManager::Installpkg)
+    } else if lower.contains("wolfi") || lower.contains("chainguard") {
+        Some(PkgManager::Apk)
+    } else {
+        None
+    }
+}
+
 /// Whether or not the `distrobox` command can be successfully run
 pub fn has_distrobox_installed() -> bool {
     let output = get_command_output("which", Some(&["distrobox"]));


### PR DESCRIPTION
Detects a box's package manager from its image name, so the .deb/.rpm install flow picks the right one instead of assuming per file type, and adds the first unit tests the repo has had.

`detect_pkg_manager` is a pure image-string → manager mapping, which made it the natural first thing to test. The test table is every image URL distrobox actually offers in `create --compatibility`, plus the docker.io shorthands people type by hand, and covers the case-insensitive match and the unknown-image `None`.

### Testing

`cargo test` — 3 passing. There's no test job in CI yet (the workflow only builds on tags), so these run locally / on demand; happy to add a `cargo test` step to CI in a follow-up if you'd want that.
