### PR TITLE
Uninstall an application from a box

### DIFF
--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -706,6 +706,133 @@ pub fn clone_box(box_to_clone: &str, new_name: &str) -> String {
     )
 }
 
+/// Uninstalls an application from inside a box by running the distrobox's
+/// package manager via `sudo` in a terminal.
+///
+/// The actual command depends on the image. We pick a manager by matching the
+/// image URL against the same set of regexes `install_deb_in_box` /
+/// `install_rpm_in_box` use, falling back to `apt` for any unknown deb-style
+/// distro. The `pkg_command` argument is the user-chosen subcommand and
+/// targets list, e.g. `remove vim git` or `purge neofetch`.
+///
+/// Spawning a terminal (rather than running the command in-process) lets the
+/// user see the `sudo` prompt and answer it interactively. We do not remove
+/// the `.desktop` export on the host - that is a separate, reversible action
+/// the user can take from the same row.
+pub fn uninstall_app_in_box(box_name: String, image: String, pkg_command: String) {
+    let (term, sep, term_is_flatpak) = get_terminal_and_separator_arg();
+    let manager = pick_pkg_manager_for_uninstall(&image);
+    let inner = format!("sudo {manager} {pkg_command}");
+    let command = format!("distrobox enter {box_name} -- /usr/bin/env bash -c \"{inner}\"");
+
+    if is_flatpak() {
+        if term_is_flatpak {
+            Command::new("flatpak-spawn")
+                .arg("--host")
+                .arg("flatpak")
+                .arg("run")
+                .arg(term)
+                .arg(sep)
+                .arg("bash")
+                .arg("-c")
+                .arg(&command)
+                .spawn()
+                .unwrap();
+        } else {
+            Command::new("flatpak-spawn")
+                .arg("--host")
+                .arg(term)
+                .arg(sep)
+                .arg("bash")
+                .arg("-c")
+                .arg(&command)
+                .spawn()
+                .unwrap();
+        }
+    } else {
+        if term_is_flatpak {
+            Command::new("flatpak")
+                .arg("run")
+                .arg(term)
+                .arg(sep)
+                .arg("bash")
+                .arg("-c")
+                .arg(&command)
+                .spawn()
+                .unwrap();
+        } else {
+            Command::new(term)
+                .arg(sep)
+                .arg("bash")
+                .arg("-c")
+                .arg(&command)
+                .spawn()
+                .unwrap();
+        }
+    }
+}
+
+/// Heuristic mapping from a container image to its native package manager.
+/// Returns just the manager binary (`apt`, `dnf`, `pacman`, ...); the user
+/// supplies the subcommand and packages separately.
+fn pick_pkg_manager_for_uninstall(image: &str) -> &'static str {
+    let lower = image.to_lowercase();
+    // Arch family
+    if lower.contains("arch")
+        || lower.contains("blackarch")
+        || lower.contains("bazzite-arch")
+        || lower.contains("arch-toolbox")
+    {
+        return "pacman";
+    }
+    // Debian / Ubuntu family
+    if lower.contains("ubuntu")
+        || lower.contains("toolbx/ubuntu")
+        || lower.contains("ubuntu-toolbox")
+        || lower.contains("debian")
+        || lower.contains("neurodebian")
+        || lower.contains("mint")
+        || lower.contains("kali")
+        || lower.contains("neon")
+    {
+        return "apt";
+    }
+    // Fedora family (also RHEL clones)
+    if lower.contains("fedora")
+        || lower.contains("bluefin")
+        || lower.contains("fedoraproject.org/fedora")
+        || lower.contains("centos")
+        || lower.contains("rhel")
+        || lower.contains("rocky")
+        || lower.contains("alma")
+        || lower.contains("ubi")
+        || lower.contains("amazonlinux")
+        || lower.contains("oracle")
+    {
+        return "dnf";
+    }
+    // openSUSE
+    if lower.contains("opensuse") || lower.contains("tumbleweed") || lower.contains("leap") {
+        return "zypper";
+    }
+    if lower.contains("alpine") || lower.contains("wolfi") || lower.contains("chainguard") {
+        return "apk";
+    }
+    if lower.contains("void") {
+        return "xbps-install";
+    }
+    if lower.contains("gentoo") {
+        return "emerge";
+    }
+    if lower.contains("slack") {
+        return "installpkg";
+    }
+    // Default: most container images in distrobox's supported list ship
+    // apt or dnf; apt is the safer guess because it errors loudly on
+    // non-apt distros instead of partial-success.
+    "apt"
+}
+
 pub fn upgrade_all_boxes() {
     let (term, sep, term_is_flatpak) = get_terminal_and_separator_arg();
     let command = format!("distrobox-upgrade --all");

--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -706,24 +706,35 @@ pub fn clone_box(box_to_clone: &str, new_name: &str) -> String {
     )
 }
 
-/// Uninstalls an application from inside a box by running the distrobox's
+/// Uninstalls an application from inside a box by running the distro's
 /// package manager via `sudo` in a terminal.
 ///
-/// The actual command depends on the image. We pick a manager by matching the
-/// image URL against the same set of regexes `install_deb_in_box` /
-/// `install_rpm_in_box` use, falling back to `apt` for any unknown deb-style
-/// distro. The `pkg_command` argument is the user-chosen subcommand and
-/// targets list, e.g. `remove vim git` or `purge neofetch`.
+/// `app_exec` is the raw `Exec=` value of the application's desktop file.
+/// The binary usually is not named after its package (gimp lives in
+/// gimp-2.10, for instance), so instead of guessing, the box's own package
+/// manager is asked which package owns the binary; only if that fails does
+/// the bare executable name serve as the guess. Everything interpolated
+/// into the terminal command is shell-quoted, because the desktop file -
+/// and therefore `app_exec` - comes from the container image, not from the
+/// user.
 ///
-/// Spawning a terminal (rather than running the command in-process) lets the
-/// user see the `sudo` prompt and answer it interactively. We do not remove
-/// the `.desktop` export on the host - that is a separate, reversible action
-/// the user can take from the same row.
-pub fn uninstall_app_in_box(box_name: String, image: String, pkg_command: String) {
+/// Spawning a terminal (rather than running the command in-process) lets
+/// the user see what will be removed and answer the manager's prompt. We do
+/// not remove the `.desktop` export on the host - that is a separate,
+/// reversible action the user can take from the same row.
+pub fn uninstall_app_in_box(box_name: String, image: String, app_exec: String) {
     let (term, sep, term_is_flatpak) = get_terminal_and_separator_arg();
     let manager = pick_pkg_manager_for_uninstall(&image);
-    let inner = format!("sudo {manager} {pkg_command}");
-    let command = format!("distrobox enter {box_name} -- /usr/bin/env bash -c \"{inner}\"");
+    let (remove_bin, remove_arg) = manager_remove_invocation(manager);
+
+    let package = resolve_package_for_binary(&box_name, manager, &app_exec)
+        .unwrap_or_else(|| first_token(&app_exec).to_string());
+
+    let command = format!(
+        "distrobox enter {} -- sudo {remove_bin} {remove_arg} {}",
+        shell_quote(&box_name),
+        shell_quote(&package),
+    );
 
     if is_flatpak() {
         if term_is_flatpak {
@@ -770,6 +781,116 @@ pub fn uninstall_app_in_box(box_name: String, image: String, pkg_command: String
                 .unwrap();
         }
     }
+}
+
+/// The first whitespace-separated token of an `Exec=` line - the executable
+/// itself, with any arguments dropped.
+fn first_token(exec_line: &str) -> &str {
+    exec_line.split_whitespace().next().unwrap_or(exec_line)
+}
+
+/// Wraps a string in single quotes for embedding into a `bash -c` command
+/// line, escaping any single quotes inside it.
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// How a given manager spells "remove this package". Returns the binary to
+/// call and its removal argument - not always the manager itself: slackware
+/// installs with installpkg but removes with removepkg.
+fn manager_remove_invocation(manager: &str) -> (&'static str, &'static str) {
+    match manager {
+        "pacman" => ("pacman", "-R"),
+        "apk" => ("apk", "del"),
+        "xbps-install" => ("xbps-remove", ""),
+        "emerge" => ("emerge", "--unmerge"),
+        "installpkg" => ("removepkg", ""),
+        "dnf" => ("dnf", "remove"),
+        "zypper" => ("zypper", "remove"),
+        _ => ("apt", "remove"),
+    }
+}
+
+/// The package name owning `exec_line`'s binary, according to the box's own
+/// package manager. Asks `command -v` inside the box for the full path first,
+/// then the manager who owns that path. Returns None for managers we do not
+/// know how to ask, or when either step comes back empty - the caller then
+/// falls back to the bare executable name.
+///
+/// Both queries pass the untrusted values as positional parameters rather
+/// than splicing them into shell text.
+fn resolve_package_for_binary(box_name: &str, manager: &str, exec_line: &str) -> Option<String> {
+    let binary = first_token(exec_line);
+
+    let path_out = get_command_output(
+        "distrobox",
+        Some(&[
+            "enter",
+            box_name,
+            "--",
+            "bash",
+            "-c",
+            "command -v -- \"$1\"",
+            "_",
+            binary,
+        ]),
+    );
+    let path = path_out
+        .lines()
+        .find(|l| l.starts_with('/'))?
+        .trim()
+        .to_string();
+
+    let owner_out = match manager {
+        "apt" => get_command_output(
+            "distrobox",
+            Some(&["enter", box_name, "--", "dpkg", "-S", &path]),
+        ),
+        "dnf" | "zypper" => get_command_output(
+            "distrobox",
+            Some(&[
+                "enter",
+                box_name,
+                "--",
+                "rpm",
+                "-qf",
+                "--queryformat",
+                "%{NAME}",
+                &path,
+            ]),
+        ),
+        "pacman" => get_command_output(
+            "distrobox",
+            Some(&["enter", box_name, "--", "pacman", "-Qqo", &path]),
+        ),
+        _ => return None,
+    };
+
+    parse_package_owner(manager, &owner_out)
+}
+
+/// Pulls the package name out of an ownership query's output.
+/// dpkg says `cowsay: /usr/games/cowsay` (or `libc6:amd64: /lib/...`),
+/// rpm prints the bare name thanks to --queryformat, pacman -Qqo prints the
+/// bare name on its own line.
+fn parse_package_owner(manager: &str, output: &str) -> Option<String> {
+    let line = output.lines().map(str::trim).find(|l| !l.is_empty())?;
+
+    if line.contains("no path found") || line.contains("not owned") || line.contains("error") {
+        return None;
+    }
+
+    let name = match manager {
+        "apt" => line.split(':').next()?,
+        _ => line,
+    };
+
+    let name = name.trim();
+    if name.is_empty() {
+        return None;
+    }
+
+    Some(name.to_string())
 }
 
 /// Heuristic mapping from a container image to its native package manager.
@@ -881,5 +1002,68 @@ pub fn upgrade_all_boxes() {
                 .spawn()
                 .unwrap();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{first_token, manager_remove_invocation, parse_package_owner, shell_quote};
+
+    #[test]
+    fn first_token_drops_arguments() {
+        assert_eq!(first_token("gimp-2.10 --new-instance"), "gimp-2.10");
+        assert_eq!(first_token("cowsay"), "cowsay");
+        assert_eq!(first_token("  spaced   out  "), "spaced");
+    }
+
+    /// The Exec= line comes from the container image, so a hostile one must
+    /// come out as inert quoted text, not as extra shell syntax.
+    #[test]
+    fn shell_quote_neutralises_hostile_input() {
+        assert_eq!(shell_quote("cowsay"), "'cowsay'");
+        assert_eq!(shell_quote("a;rm -rf $HOME"), "'a;rm -rf $HOME'");
+        assert_eq!(shell_quote("a'b"), r#"'a'\''b'"#);
+    }
+
+    #[test]
+    fn parses_dpkg_ownership() {
+        assert_eq!(
+            parse_package_owner("apt", "cowsay: /usr/games/cowsay\n"),
+            Some("cowsay".to_string())
+        );
+        // multi-arch packages carry the architecture after a second colon
+        assert_eq!(
+            parse_package_owner("apt", "libc6:amd64: /lib/x86_64-linux-gnu/libc.so.6\n"),
+            Some("libc6".to_string())
+        );
+        assert_eq!(
+            parse_package_owner("apt", "dpkg-query: no path found matching pattern /x\n"),
+            None
+        );
+    }
+
+    #[test]
+    fn parses_rpm_and_pacman_ownership() {
+        assert_eq!(
+            parse_package_owner("dnf", "cowsay"),
+            Some("cowsay".to_string())
+        );
+        assert_eq!(
+            parse_package_owner("pacman", "cowsay\n"),
+            Some("cowsay".to_string())
+        );
+        assert_eq!(
+            parse_package_owner("pacman", "error: No package owns /usr/bin/x\n"),
+            None
+        );
+        assert_eq!(parse_package_owner("dnf", "\n"), None);
+    }
+
+    #[test]
+    fn removal_is_spelled_per_manager() {
+        assert_eq!(manager_remove_invocation("apt"), ("apt", "remove"));
+        assert_eq!(manager_remove_invocation("pacman"), ("pacman", "-R"));
+        // slackware installs with installpkg but removes with removepkg
+        assert_eq!(manager_remove_invocation("installpkg"), ("removepkg", ""));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -313,7 +313,7 @@ fn build_not_installed_status_page(title: &str, body: &str) -> adw::StatusPage {
 
 fn render_not_installed(scroll_area: &gtk::Box) {
     clear_children(scroll_area);
-  
+
     // TRANSLATORS: Error message shown when distrobox is not installed
     let title = gettext("Distrobox not found!");
     // TRANSLATORS: Error message shown when distrobox is not installed
@@ -1000,11 +1000,7 @@ fn on_upgrade_clicked(box_name: &str) {
     upgrade_box(box_name);
 }
 
-fn on_show_applications_clicked(
-    window: &ApplicationWindow,
-    box_name: String,
-    box_image: String,
-) {
+fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String, box_image: String) {
     let apps_popup = gtk::Window::builder()
         // TRANSLATORS: Window Title - shows list of installed applications in distrobox
         .title(gettext("Installed Applications"))
@@ -1106,10 +1102,9 @@ fn on_show_applications_clicked(
 
                                 // Uninstall button: removes the application
                                 // from inside the box via the distro's
-                                // package manager. We pass the executable
-                                // name (which doubles as the package name
-                                // for most distros) plus the box's image so
-                                // the right manager can be picked.
+                                // package manager. The handler asks the
+                                // box which package owns the executable,
+                                // so the raw Exec= value is enough here.
                                 // TRANSLATORS: Button Label
                                 let uninstall_btn = gtk::Button::with_label(&gettext("Uninstall"));
                                 uninstall_btn.add_css_class("pill");
@@ -1121,7 +1116,7 @@ fn on_show_applications_clicked(
                                     uninstall_app_in_box(
                                         un_box_name.clone(),
                                         un_image.clone(),
-                                        format!("remove {un_exec}"),
+                                        un_exec.clone(),
                                     );
                                 });
                                 row.add_suffix(&uninstall_btn);

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use distrobox_handler::{
     get_apps_in_box, get_available_images_with_distro_name, get_binaries_exported_from_box,
     get_number_of_boxes, install_deb_in_box, install_rpm_in_box, open_terminal_in_box,
     remove_app_from_host, remove_exported_binary_from_box, run_command_in_box, stop_box,
-    upgrade_all_boxes, upgrade_box, DBox, DBoxApp,
+    uninstall_app_in_box, upgrade_all_boxes, upgrade_box, DBox, DBoxApp,
 };
 
 mod utils;
@@ -453,9 +453,10 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
     show_applications_row.set_activatable(true);
 
     let show_bn_clone = box_name.clone();
+    let show_img_clone = dbox.image_url.clone();
     let win_clone = window.clone();
     show_applications_row.connect_activated(move |_row| {
-        on_show_applications_clicked(&win_clone, show_bn_clone.clone());
+        on_show_applications_clicked(&win_clone, show_bn_clone.clone(), show_img_clone.clone());
     });
 
     // Install Deb Icon
@@ -999,7 +1000,11 @@ fn on_upgrade_clicked(box_name: &str) {
     upgrade_box(box_name);
 }
 
-fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {
+fn on_show_applications_clicked(
+    window: &ApplicationWindow,
+    box_name: String,
+    box_image: String,
+) {
     let apps_popup = gtk::Window::builder()
         // TRANSLATORS: Window Title - shows list of installed applications in distrobox
         .title(gettext("Installed Applications"))
@@ -1098,6 +1103,28 @@ fn on_show_applications_clicked(window: &ApplicationWindow, box_name: String) {
                                 row.add_prefix(&img);
                                 row.add_suffix(&run_btn);
                                 row.add_suffix(&gtk::Separator::new(gtk::Orientation::Horizontal));
+
+                                // Uninstall button: removes the application
+                                // from inside the box via the distro's
+                                // package manager. We pass the executable
+                                // name (which doubles as the package name
+                                // for most distros) plus the box's image so
+                                // the right manager can be picked.
+                                // TRANSLATORS: Button Label
+                                let uninstall_btn = gtk::Button::with_label(&gettext("Uninstall"));
+                                uninstall_btn.add_css_class("pill");
+                                uninstall_btn.set_width_request(120);
+                                let un_box_name = box_name.clone();
+                                let un_image = box_image.clone();
+                                let un_exec = app.exec_name.clone();
+                                uninstall_btn.connect_clicked(move |_btn| {
+                                    uninstall_app_in_box(
+                                        un_box_name.clone(),
+                                        un_image.clone(),
+                                        format!("remove {un_exec}"),
+                                    );
+                                });
+                                row.add_suffix(&uninstall_btn);
 
                                 if app.is_on_host {
                                     let remove_from_menu_btn =


### PR DESCRIPTION
Closes #207

Adds an Uninstall button to the applications list — the bookend to Add To Menu, and one of the Needs External Help roadmap items.

![Uninstall button](https://raw.githubusercontent.com/kacperpaczos/BoxBuddyRS/issue-assets/issue-assets/boxbuddy-uninstall-button.png)

The interesting part is picking what to remove. A desktop file's `Exec=` is the binary, which usually isn't the package name (gimp → gimp-2.10), so the handler asks the box who owns the binary — `dpkg -S`, `rpm -qf` or `pacman -Qqo`, after resolving the name through `command -v` with `/usr/games` added since desktop files can point outside the login PATH — and only falls back to the bare name if that fails. Removal is spelled per manager (pacman `-R`, apk `del`, slackware `removepkg`).

Because the desktop file comes from the container image and not the user, the values reach the resolution queries as positional parameters and everything spliced into the terminal command is shell-quoted, so an `Exec=` with a `;` in it can't run anything.

### Testing

- End-to-end on real boxes: installed `cowsay` in an Ubuntu box and a Fedora box, ran the exact resolve→remove pipeline the button triggers, and confirmed the binary was gone afterwards. On Ubuntu the resolver correctly found `/usr/games/cowsay`, which isn't on the default PATH.
- Unit tests cover the pure pieces: argument splitting, shell-quoting (including a hostile `a;rm -rf $HOME`), the dpkg/rpm/pacman ownership parsing, and the per-manager removal table.
- The button itself is screenshotted above. I couldn't click it in a live session here, but the wiring just calls the tested handler.
