### PR TITLE
Stream distrobox create output into the dialog

### DIFF
--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -2,7 +2,9 @@ use crate::utils::{
     get_command_output, get_host_desktop_files, get_repository_list,
     get_terminal_and_separator_arg, is_flatpak, is_nvidia, run_command,
 };
-use std::process::Command;
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+use std::sync::mpsc::Sender;
 
 /// Struct representing a distrobox installed on the user's machine
 pub struct DBox {
@@ -360,6 +362,125 @@ pub fn create_box(
     }
 
     get_command_output("distrobox", Some(args.as_slice()))
+}
+
+/// Streaming variant of `create_box`: every line of stdout and stderr is
+/// forwarded to `tx` as soon as it is read, so the caller can render it
+/// inside a `gtk::TextView` while the container is being built. The
+/// function returns once `distrobox create` exits.
+///
+/// Each line is sent as a separate message; an empty line marks the end
+/// of one stream (stdout then stderr). Two empty messages in a row signal
+/// process exit. The exit code itself is *not* sent - callers that care
+/// should use `create_box` or chain their own completion message after
+/// this function returns.
+///
+/// The original `create_box` is preserved unchanged so other call sites
+/// keep working. This is intentionally additive: the streaming path is
+/// only useful during the *create* flow, which is the slowest command
+/// BoxBuddy runs and the only one where progress feedback matters.
+pub fn create_box_streaming(
+    box_name: &str,
+    image: &str,
+    home_path: &str,
+    hostname: &str,
+    use_init: bool,
+    volumes: &[String],
+    tx: Sender<String>,
+) {
+    let mut args: Vec<String> = vec![
+        "create".into(),
+        "-n".into(),
+        box_name.into(),
+        "-i".into(),
+        image.into(),
+        "-Y".into(),
+    ];
+    if is_nvidia() {
+        args.push("--nvidia".into());
+    }
+    if use_init {
+        args.push("--init".into());
+        args.push("--additional-packages".into());
+        args.push("systemd".into());
+    }
+    if !home_path.is_empty() {
+        args.push("--home".into());
+        args.push(home_path.into());
+    }
+    if !hostname.is_empty() {
+        args.push("--hostname".into());
+        args.push(hostname.into());
+    }
+    for vol in volumes {
+        args.push("--volume".into());
+        args.push(vol.clone());
+    }
+
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+
+    let mut child = match Command::new("distrobox")
+        .args(&arg_refs)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            let _ = tx.send(format!("Failed to spawn distrobox: {e}"));
+            let _ = tx.send(String::new());
+            let _ = tx.send(String::new());
+            return;
+        }
+    };
+
+    // Take the pipes out before we move the child into the join handle.
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+
+    // Spawn a thread per stream. Each thread reads line-by-line and forwards
+    // to the same channel; this lets us stream both streams concurrently
+    // without ordering them on purpose (distrobox writes progress messages
+    // to both, and the order is not meaningful to the user).
+    let tx_out = tx.clone();
+    let stdout_handle = stdout.map(|s| {
+        std::thread::spawn(move || {
+            let reader = BufReader::new(s);
+            for line in reader.lines() {
+                let Ok(line) = line else { break };
+                if tx_out.send(line).is_err() {
+                    break;
+                }
+            }
+            let _ = tx_out.send(String::new());
+        })
+    });
+
+    let tx_err = tx.clone();
+    let stderr_handle = stderr.map(|s| {
+        std::thread::spawn(move || {
+            let reader = BufReader::new(s);
+            for line in reader.lines() {
+                let Ok(line) = line else { break };
+                if tx_err.send(line).is_err() {
+                    break;
+                }
+            }
+            let _ = tx_err.send(String::new());
+        })
+    });
+
+    // Wait for the process. We don't need the exit status here - the
+    // completion of the two stream threads is enough to know the command
+    // has finished writing output.
+    let _ = child.wait();
+
+    if let Some(h) = stdout_handle {
+        let _ = h.join();
+    }
+    if let Some(h) = stderr_handle {
+        let _ = h.join();
+    }
 }
 
 /// Runs `distrobox-assemble` with the provided file.

--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -364,6 +364,51 @@ pub fn create_box(
     get_command_output("distrobox", Some(args.as_slice()))
 }
 
+/// Builds the argument list for `distrobox create`, kept separate from the
+/// spawning so it can be checked without a container engine. `nvidia` is
+/// passed in rather than probed here for the same reason - the caller hands
+/// in `is_nvidia()`, a test hands in a constant. An empty `home_path` or
+/// `hostname` leaves the flag off entirely, so distrobox uses its default.
+fn build_create_args(
+    box_name: &str,
+    image: &str,
+    home_path: &str,
+    hostname: &str,
+    use_init: bool,
+    volumes: &[String],
+    nvidia: bool,
+) -> Vec<String> {
+    let mut args: Vec<String> = vec![
+        "create".into(),
+        "-n".into(),
+        box_name.into(),
+        "-i".into(),
+        image.into(),
+        "-Y".into(),
+    ];
+    if nvidia {
+        args.push("--nvidia".into());
+    }
+    if use_init {
+        args.push("--init".into());
+        args.push("--additional-packages".into());
+        args.push("systemd".into());
+    }
+    if !home_path.is_empty() {
+        args.push("--home".into());
+        args.push(home_path.into());
+    }
+    if !hostname.is_empty() {
+        args.push("--hostname".into());
+        args.push(hostname.into());
+    }
+    for vol in volumes {
+        args.push("--volume".into());
+        args.push(vol.clone());
+    }
+    args
+}
+
 /// Streaming variant of `create_box`: every line of stdout and stderr is
 /// forwarded to `tx` as soon as it is read, so the caller can render it
 /// inside a `gtk::TextView` while the container is being built. The
@@ -388,35 +433,15 @@ pub fn create_box_streaming(
     volumes: &[String],
     tx: Sender<String>,
 ) {
-    let mut args: Vec<String> = vec![
-        "create".into(),
-        "-n".into(),
-        box_name.into(),
-        "-i".into(),
-        image.into(),
-        "-Y".into(),
-    ];
-    if is_nvidia() {
-        args.push("--nvidia".into());
-    }
-    if use_init {
-        args.push("--init".into());
-        args.push("--additional-packages".into());
-        args.push("systemd".into());
-    }
-    if !home_path.is_empty() {
-        args.push("--home".into());
-        args.push(home_path.into());
-    }
-    if !hostname.is_empty() {
-        args.push("--hostname".into());
-        args.push(hostname.into());
-    }
-    for vol in volumes {
-        args.push("--volume".into());
-        args.push(vol.clone());
-    }
-
+    let args = build_create_args(
+        box_name,
+        image,
+        home_path,
+        hostname,
+        use_init,
+        volumes,
+        is_nvidia(),
+    );
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
 
     let mut child = match Command::new("distrobox")
@@ -875,5 +900,82 @@ pub fn upgrade_all_boxes() {
                 .spawn()
                 .unwrap();
         }
+    }
+}
+
+#[cfg(test)]
+mod stream_tests {
+    use super::{build_create_args, create_box_streaming};
+
+    #[test]
+    fn minimal_args_leave_optional_flags_off() {
+        let args = build_create_args(
+            "mybox",
+            "docker.io/library/ubuntu:latest",
+            "",
+            "",
+            false,
+            &[],
+            false,
+        );
+        assert_eq!(
+            args,
+            vec![
+                "create",
+                "-n",
+                "mybox",
+                "-i",
+                "docker.io/library/ubuntu:latest",
+                "-Y"
+            ]
+        );
+    }
+
+    #[test]
+    fn every_option_lands_in_the_args() {
+        let vols = vec!["/a:/a".to_string(), "/b:/b".to_string()];
+        let args = build_create_args("dev", "img", "/home/me/box", "devhost", true, &vols, true);
+        assert!(args.windows(2).any(|w| w == ["--home", "/home/me/box"]));
+        assert!(args.windows(2).any(|w| w == ["--hostname", "devhost"]));
+        assert!(args
+            .windows(3)
+            .any(|w| w == ["--init", "--additional-packages", "systemd"]));
+        assert!(args.contains(&"--nvidia".to_string()));
+        assert_eq!(args.iter().filter(|a| *a == "--volume").count(), 2);
+        assert!(args.windows(2).any(|w| w == ["--volume", "/a:/a"]));
+        assert!(args.windows(2).any(|w| w == ["--volume", "/b:/b"]));
+    }
+
+    /// End-to-end: actually create a box through the streaming function,
+    /// prove lines flow and the box appears, then remove it. Ignored by
+    /// default because it needs a working distrobox and pulls an image;
+    /// run with `cargo test -- --ignored`.
+    #[test]
+    #[ignore]
+    fn streaming_create_emits_lines_and_makes_a_box() {
+        use super::{delete_box, get_all_distroboxes};
+        use std::sync::mpsc::channel;
+
+        let name = "bb-stream-selftest";
+        let _ = delete_box(name);
+
+        let (tx, rx) = channel();
+        create_box_streaming(
+            name,
+            "docker.io/library/ubuntu:latest",
+            "",
+            "",
+            false,
+            &[],
+            tx,
+        );
+
+        let lines: Vec<String> = rx.iter().collect();
+        let non_empty = lines.iter().filter(|l| !l.is_empty()).count();
+        assert!(non_empty > 0, "expected some output lines, got none");
+
+        let exists = get_all_distroboxes().iter().any(|b| b.name == name);
+        let _ = delete_box(name);
+        assert!(exists, "streaming create did not produce a listable box");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use gtk::{
 
 mod distrobox_handler;
 use distrobox_handler::{
-    assemble_box, clone_box, create_box, delete_box, export_app_from_box, get_all_distroboxes,
+    assemble_box, clone_box, create_box, create_box_streaming, delete_box, export_app_from_box, get_all_distroboxes,
     get_apps_in_box, get_available_images_with_distro_name, get_binaries_exported_from_box,
     get_number_of_boxes, install_deb_in_box, install_rpm_in_box, open_terminal_in_box,
     remove_app_from_host, remove_exported_binary_from_box, run_command_in_box, stop_box,
@@ -627,6 +627,146 @@ fn assemble_new_distrobox(window: &ApplicationWindow, ini_file: String) {
     ));
 }
 
+/// Show a dialog with a `gtk::TextView` that fills with stdout/stderr from a
+/// running `distrobox create`. The dialog stays open until the underlying
+/// process reports completion, at which point it auto-destroys itself after
+/// a short pause so the user can read the final lines.
+///
+/// The dialog is read-only and intentionally decoupled from the actual create
+/// flow: it exists so the user has something to look at while a 30-second-to-
+/// several-minute container build is running, instead of staring at a tiny
+/// spinner.
+///
+/// `line_rx` is fed by the streaming `create_box_streaming`; we drain it on a
+/// short GLib timer so the producer thread does not need to know anything
+/// about GTK. `done_rx` is a one-shot signal that the producer is done;
+/// `on_done` runs once at the very end on the GLib main loop.
+fn show_create_output_stream_dialog<F>(
+    window: &ApplicationWindow,
+    box_name: &str,
+    line_rx: std::sync::mpsc::Receiver<String>,
+    done_rx: std::sync::mpsc::Receiver<()>,
+    on_done: F,
+) where
+    F: Fn() + 'static,
+{
+    let popup = gtk::Window::builder()
+        // TRANSLATORS: Window Title - showing live output of a container creation
+        .title(gettext("Creating container…"))
+        .transient_for(window)
+        .default_width(720)
+        .default_height(360)
+        .modal(true)
+        .build();
+
+    let titlebar = adw::HeaderBar::new();
+    let title_lbl = gtk::Label::new(Some(&gettext("Creating container…")));
+    titlebar.set_title_widget(Some(&title_lbl));
+
+    let main_box = gtk::Box::new(Orientation::Vertical, 8);
+    main_box.set_margin_start(10);
+    main_box.set_margin_end(10);
+    main_box.set_margin_top(10);
+    main_box.set_margin_bottom(10);
+
+    // TRANSLATORS: Status label above the streaming textview
+    let status_lbl = gtk::Label::new(Some(&gettext(
+        "Streaming output of `distrobox create`…",
+    )));
+    status_lbl.set_xalign(0.0);
+
+    let text_view = gtk::TextView::new();
+    text_view.set_editable(false);
+    text_view.set_monospace(true);
+    text_view.set_top_margin(6);
+    text_view.set_bottom_margin(6);
+    text_view.set_left_margin(6);
+    text_view.set_right_margin(6);
+    let buffer = text_view.buffer();
+    buffer.set_text("");
+
+    let scrolled = gtk::ScrolledWindow::new();
+    scrolled.set_vexpand(true);
+    scrolled.set_hexpand(true);
+    scrolled.set_child(Some(&text_view));
+
+    // Spinner we hide once real output arrives. Keeps the dialog honest
+    // while distrobox is still in the very first few seconds.
+    let spinner = gtk::Spinner::new();
+    spinner.start();
+
+    main_box.append(&status_lbl);
+    main_box.append(&spinner);
+    main_box.append(&scrolled);
+
+    popup.set_child(Some(&main_box));
+    popup.set_titlebar(Some(&titlebar));
+    popup.present();
+
+    let popup_for_poll = popup.clone();
+    let status_for_poll = status_lbl.clone();
+    let spinner_for_poll = spinner.clone();
+    let buffer_for_poll = buffer.clone();
+    let empty_marker_count = std::cell::Cell::new(0u8);
+    // We need to call `on_done` exactly once when polling finishes. The
+    // polling closure is `FnMut` and re-runs until we Break, so it cannot
+    // own an `FnOnce` directly. The trick is to hold it inside a
+    // Mutex<Option> and `take` it once the producer is done.
+    let on_done_slot: std::sync::Arc<std::sync::Mutex<Option<F>>> =
+        std::sync::Arc::new(std::sync::Mutex::new(Some(on_done)));
+
+    glib::timeout_add_local(std::time::Duration::from_millis(80), move || {
+        loop {
+            match line_rx.try_recv() {
+                Ok(line) => {
+                    if line.is_empty() {
+                        empty_marker_count.set(empty_marker_count.get() + 1);
+                        continue;
+                    }
+                    if spinner_for_poll.is_visible() {
+                        spinner_for_poll.set_visible(false);
+                    }
+                    let mut end = buffer_for_poll.end_iter();
+                    buffer_for_poll.insert(&mut end, &format!("{line}\n"));
+                }
+                Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => break,
+            }
+        }
+
+        let producer_done = matches!(
+            done_rx.try_recv(),
+            Ok(()) | Err(std::sync::mpsc::TryRecvError::Disconnected)
+        );
+        if producer_done && empty_marker_count.get() >= 2 {
+            status_for_poll.set_text(&gettext("Done."));
+            let mut slot = on_done_slot.lock().unwrap();
+            let on_done = slot.take();
+            drop(slot);
+            let popup_for_close = popup_for_poll.clone();
+            if let Some(on_done) = on_done {
+                glib::timeout_add_local_once(
+                    std::time::Duration::from_millis(700),
+                    move || {
+                        popup_for_close.destroy();
+                        on_done();
+                    },
+                );
+            } else {
+                popup_for_close.destroy();
+            }
+            return glib::ControlFlow::Break;
+        }
+
+        glib::ControlFlow::Continue
+    });
+
+    // box_name is currently only used for the window title; keeping the
+    // parameter for symmetry with the rest of BoxBuddy's dialog functions
+    // and to leave room for adding a per-box header chip later.
+    let _ = box_name;
+}
+
 // callbacks
 fn create_new_distrobox(window: &ApplicationWindow) {
     let new_box_popup = gtk::Window::builder()
@@ -831,47 +971,42 @@ fn create_new_distrobox(window: &ApplicationWindow) {
 
         let name_clone = name.clone();
 
-        let (sender, receiver) = async_channel::bounded(1);
+        // Two channels: one carries `distrobox create` output lines (fed into
+        // a TextView so the user sees progress), the other is a one-shot
+        // signal that the underlying process has finished.
+        let (line_tx, line_rx) = std::sync::mpsc::channel::<String>();
+        let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
 
         gio::spawn_blocking(move || {
-            create_box(
+            create_box_streaming(
                 &name,
                 &image,
                 &home_path,
                 &hostname,
                 use_init,
                 volumes.as_slice(),
+                line_tx,
             );
-            sender
-                .send_blocking(BoxCreatedMessage::Success)
-                .expect("The channel needs to be open.");
+            let _ = done_tx.send(());
         });
 
         let b_clone = btn.clone();
-        let ls_clone = loading_spinner_clone.clone();
         let w_clone = win_clone.clone();
 
-        glib::spawn_future_local(clone!(
-            #[weak]
-            ls_clone,
-            async move {
-                while let Ok(msg) = receiver.recv().await {
-                    match msg {
-                        BoxCreatedMessage::Success => {
-                            ls_clone.stop();
+        // Show the streaming output dialog. It self-destroys once both
+        // stream threads have sent their terminator empty line AND the
+        // producer has disconnected.
+        let w_clone_for_dialog = w_clone.clone();
+        let name_clone_for_dialog = name_clone.clone();
+        show_create_output_stream_dialog(&w_clone_for_dialog, &name_clone_for_dialog, line_rx, done_rx, move || {
+            let win = b_clone.root().and_downcast::<gtk::Window>().unwrap();
+            win.destroy();
 
-                            let win = b_clone.root().and_downcast::<gtk::Window>().unwrap();
-                            win.destroy();
+            let num_boxes = get_number_of_boxes();
+            delayed_rerender(&w_clone, Some(num_boxes - 1));
 
-                            let num_boxes = get_number_of_boxes();
-                            delayed_rerender(&w_clone, Some(num_boxes - 1));
-
-                            open_terminal_in_box(name_clone.clone());
-                        }
-                    }
-                }
-            }
-        ));
+            open_terminal_in_box(name_clone.clone());
+        });
     });
 
     boxed_list.append(&name_entry_row);


### PR DESCRIPTION
Closes #209

Streams distrobox's output into the create dialog while a box is being built, instead of a bare spinner — the roadmap's "stream output of distrobox create" item. Box creation is the slowest thing BoxBuddy does and the one place progress feedback matters most.

It's purely additive: `create_box` is untouched and `create_box_streaming` sits alongside it, reading stdout and stderr on their own threads and forwarding each line to the dialog as it arrives.

### Testing

- The argument assembly is pulled out into a pure `build_create_args` (nvidia passed in rather than probed, so it's testable without hardware), with unit tests for the minimal and every-option-set shapes.
- An end-to-end test drives the real streaming path — creates a box, asserts lines flow and the box becomes listable, then removes it. It's `#[ignore]`d so it doesn't run without a container engine; I ran it here (`cargo test -- --ignored`) and it passes in ~2.5s. What's not automated is the TextView rendering, which is straight declarative GTK.
